### PR TITLE
OPHJOD-241: Fix storybook workflow and prepare step

### DIFF
--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           path: storybook-static
           checkout: false
-          build_command: build:storybook
+          build_command: npm run build:storybook

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -1,9 +1,10 @@
 name: Build and Publish Storybook to GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - 'main'
+      - main
 
 permissions:
   contents: read
@@ -11,18 +12,45 @@ permissions:
   id-token: write
 
 jobs:
-  deploy:
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: lts/iron
           cache: npm
+      - name: Install dependencies
+        run: npm ci
 
-      - uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
+      - name: Run ESLint
+        run: 'npx eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0'
+      - name: Prettier
+        run: npx prettier . --check
+
+      - name: Unit tests
+        run: npx vitest --run
+
+      - name: Run build
+        run: npm run build:storybook
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          path: storybook-static
-          checkout: false
-          build_command: npm run build:storybook
+          path: storybook-static/
+
+  deploy:
+    name: Deploy
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    environment: development
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          token: ${{ github.token }}

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -7,15 +7,13 @@ import classNames from 'classnames';
 export type ButtonVariant = 'base' | 'primary' | 'outlined' | 'text';
 
 export interface ButtonProps {
-  /* Text shown on the button*/
+  /** Text shown on the button */
   label: string;
-  /* Callback fired on tap/click of the button */
+  /** Callback fired on tap/click of the button */
   onClick: () => void;
-  /** 
-   Variant of the button 
-   */
+  /** Variant of the button */
   variant?: ButtonVariant;
-  /* Button disabled for any actions */
+  /** Button disabled for any actions */
   disabled?: boolean;
 }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "preview": "vite preview",
     "storybook": "BROWSER=none storybook dev -p 6006",
     "build:storybook": "storybook build",
-    "prepare": "husky"
+    "prepare": "husky && npm run build"
   },
   "peerDependencies": {
     "classnames": "^2.5.1",


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Fix `build_command` for the storybook's workflow; missing the `npm run`
- Fix the `prepare` script to include `npm run build`
- Replace the premade script with own to have more control (to deploy built storybook to GH Pages)


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-241
