### PR TITLE
OPHJOD-263: Fix CSS import for bundled JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "typescript": "^5.2.2",
         "vite": "^5.1.4",
         "vite-plugin-dts": "^3.7.3",
+        "vite-plugin-lib-inject-css": "^2.0.0",
         "vitest": "^1.3.1"
       },
       "peerDependencies": {
@@ -15819,6 +15820,19 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-lib-inject-css": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-lib-inject-css/-/vite-plugin-lib-inject-css-2.0.0.tgz",
+      "integrity": "sha512-5RK9eP2biW340FEbpI8eHZQfeqIz0+Glbkk4U1fZ1QKOvyaYy5K6TmW43KuhmGLizk2Vd4Nv7OwGpxq2wXclyQ==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.7",
+        "picocolors": "^1.0.0"
+      },
+      "peerDependencies": {
+        "vite": "*"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "typescript": "^5.2.2",
     "vite": "^5.1.4",
     "vite-plugin-dts": "^3.7.3",
+    "vite-plugin-lib-inject-css": "^2.0.0",
     "vitest": "^1.3.1"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,13 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
+import { libInjectCss } from 'vite-plugin-lib-inject-css';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), dts({ include: ['lib'], exclude: ['lib/**/*.stories.{ts,tsx}'] })],
+  plugins: [react(), libInjectCss(), dts({ include: ['lib'], exclude: ['lib/**/*.stories.{ts,tsx}'] })],
   test: {
     environment: 'jsdom',
   },


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Update bundled JS to import styles; no need to import separate css in the project where using the library.
  - Using `vite-plugin-lib-inject-css` 


## More details
This part was gone with the bathing water when rebasing/reordering commits. 


```tsx
import { Button } from 'jod-design-system';
import 'jod-design-system/dist/style.css';
//...
<Button label='ABC' variant='primary' onClick={() => console.log('clicked!')}>Click me</Button>
```



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-263
