### PR TITLE
OPHJOD-511: Remove negative margin from Accordion icon button

### DIFF
--- a/lib/components/Accordion/Accordion.tsx
+++ b/lib/components/Accordion/Accordion.tsx
@@ -31,7 +31,7 @@ export const Accordion = ({ title, children, expandLessText, expandMoreText, lan
             }}
             className="flex"
           >
-            <span className="material-symbols-outlined size-32 m-[-5px] select-none font-bold" aria-hidden>
+            <span className="material-symbols-outlined size-32 select-none font-bold" aria-hidden>
               {isOpen ? 'expand_less' : 'expand_more'}
             </span>
           </button>
@@ -47,7 +47,7 @@ export const Accordion = ({ title, children, expandLessText, expandMoreText, lan
           <div className="hyphens-auto text-heading-4" lang={lang}>
             {title}
           </div>
-          <span className="material-symbols-outlined size-32 m-[-5px] select-none font-bold" aria-hidden>
+          <span className="material-symbols-outlined size-32 select-none font-bold" aria-hidden>
             {isOpen ? 'expand_less' : 'expand_more'}
           </span>
         </button>

--- a/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Accordion > renders accordion with open state by default 1`] = `
   </div>
   <span
     aria-hidden="true"
-    class="material-symbols-outlined size-32 m-[-5px] select-none font-bold"
+    class="material-symbols-outlined size-32 select-none font-bold"
   >
     expand_less
   </span>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Remove the minus margin from the Accordion's icon button.

Was causing issues elsewhere where using Accordion component in Modal; horizontal scrolls appeared. And not seeing use for these margins.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-511
