### PR TITLE
OPHJOD-540: Replace primary-gray with black in css classes

### DIFF
--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -38,8 +38,8 @@ const getIconClassName = (size: ButtonProps['size'], leftIcon: boolean, rightIco
 
 const getVariantClassName = (variant: ButtonProps['variant'], disabled: ButtonProps['disabled']) => {
   return cx({
-    'text-primary-gray bg-bg-gray': variant === 'gray',
-    'text-primary-gray bg-white': variant === 'white',
+    'text-black bg-bg-gray': variant === 'gray',
+    'text-black bg-white': variant === 'white',
     'text-alert bg-bg-gray hover:text-alert active:text-white focus-visible:text-alert': variant === 'gray-delete',
     'text-alert bg-white hover:text-alert active:text-white focus-visible:text-alert': variant === 'white-delete',
     'active:bg-alert': (variant === 'gray-delete' || variant === 'white-delete') && !disabled,

--- a/lib/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/lib/components/Button/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button > calls the onClick function when clicked 1`] = `
 <button
-  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 text-primary-gray bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
+  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 text-black bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
   type="button"
 >
   <span
@@ -15,7 +15,7 @@ exports[`Button > calls the onClick function when clicked 1`] = `
 
 exports[`Button > renders the button as disabled 1`] = `
 <button
-  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 text-primary-gray bg-bg-gray disabled:text-inactive-gray disabled:cursor-not-allowed"
+  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 text-black bg-bg-gray disabled:text-inactive-gray disabled:cursor-not-allowed"
   disabled=""
   type="button"
 >
@@ -29,7 +29,7 @@ exports[`Button > renders the button as disabled 1`] = `
 
 exports[`Button > renders the button with an icon on the left side 1`] = `
 <button
-  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 pl-4 text-primary-gray bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
+  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 pl-4 text-black bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
   type="button"
 >
   <span
@@ -48,7 +48,7 @@ exports[`Button > renders the button with an icon on the left side 1`] = `
 
 exports[`Button > renders the button with an icon on the right side 1`] = `
 <button
-  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 pr-4 text-primary-gray bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
+  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 pr-4 text-black bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
   type="button"
 >
   <span
@@ -67,7 +67,7 @@ exports[`Button > renders the button with an icon on the right side 1`] = `
 
 exports[`Button > renders the button with the correct label 1`] = `
 <button
-  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 text-primary-gray bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
+  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 text-black bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
   type="button"
 >
   <span
@@ -80,7 +80,7 @@ exports[`Button > renders the button with the correct label 1`] = `
 
 exports[`Button > renders the button with the correct size 1`] = `
 <button
-  class="flex items-center gap-4 rounded-[30px] select-none group text-button-sm px-6 text-primary-gray bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
+  class="flex items-center gap-4 rounded-[30px] select-none group text-button-sm px-6 text-black bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
   type="button"
 >
   <span
@@ -93,7 +93,7 @@ exports[`Button > renders the button with the correct size 1`] = `
 
 exports[`Button > renders the button with the correct variant 1`] = `
 <button
-  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 text-primary-gray bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
+  class="flex items-center gap-4 rounded-[30px] select-none group text-button-md px-6 text-black bg-bg-gray hover:text-accent focus-visible:text-accent active:bg-accent focus-visible:outline-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] active:text-white active:outline-0"
   type="button"
 >
   <span

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -38,7 +38,7 @@ export const Checkbox = ({ name, disabled, value, checked, onChange, label, aria
         checked={checked}
         onChange={onChange}
         aria-label={label ? undefined : ariaLabel}
-        className="peer relative size-6 min-h-6 min-w-6 appearance-none rounded-none border-2 border-primary-gray accent-accent checked:border-accent hover:rounded-none hover:border-accent disabled:border-border-gray"
+        className="peer relative size-6 min-h-6 min-w-6 appearance-none rounded-none border-2 border-black accent-accent checked:border-accent hover:rounded-none hover:border-accent disabled:border-border-gray"
       />
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -53,7 +53,7 @@ export const Checkbox = ({ name, disabled, value, checked, onChange, label, aria
       {label && (
         <label
           htmlFor={id}
-          className={`flex flex-row items-center text-button-md text-primary-gray peer-hover:text-accent peer-hover:underline peer-disabled:text-border-gray peer-disabled:no-underline ${!isLabelValidElement ? 'pl-4' : ''}`.trim()}
+          className={`flex flex-row items-center text-button-md text-black peer-hover:text-accent peer-hover:underline peer-disabled:text-border-gray peer-disabled:no-underline ${!isLabelValidElement ? 'pl-4' : ''}`.trim()}
         >
           {label}
         </label>

--- a/lib/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/lib/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Checkbox > renders correctly 1`] = `
   class="flex items-center text-left"
 >
   <input
-    class="peer relative size-6 min-h-6 min-w-6 appearance-none rounded-none border-2 border-primary-gray accent-accent checked:border-accent hover:rounded-none hover:border-accent disabled:border-border-gray"
+    class="peer relative size-6 min-h-6 min-w-6 appearance-none rounded-none border-2 border-black accent-accent checked:border-accent hover:rounded-none hover:border-accent disabled:border-border-gray"
     id=":r0:"
     name="myCheckbox"
     type="checkbox"
@@ -27,7 +27,7 @@ exports[`Checkbox > renders correctly 1`] = `
     />
   </svg>
   <label
-    class="flex flex-row items-center text-button-md text-primary-gray peer-hover:text-accent peer-hover:underline peer-disabled:text-border-gray peer-disabled:no-underline pl-4"
+    class="flex flex-row items-center text-button-md text-black peer-hover:text-accent peer-hover:underline peer-disabled:text-border-gray peer-disabled:no-underline pl-4"
     for=":r0:"
   >
     My Checkbox

--- a/lib/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/lib/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -79,7 +79,7 @@ export const Destructive: Story = {
 const Button = ({ label, onClick }: { label: string; onClick?: () => void }) => {
   return (
     <button
-      className="group flex select-none items-center gap-4 rounded-[30px] bg-white px-6 text-button-md text-primary-gray hover:text-accent focus-visible:text-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-accent active:bg-accent active:text-white active:outline-0"
+      className="group flex select-none items-center gap-4 rounded-[30px] bg-white px-6 text-button-md text-black hover:text-accent focus-visible:text-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-accent active:bg-accent active:text-white active:outline-0"
       onClick={onClick}
     >
       <span className="py-[10px] group-hover:underline group-focus-visible:no-underline group-active:no-underline">

--- a/lib/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/lib/components/ConfirmDialog/ConfirmDialog.tsx
@@ -33,7 +33,7 @@ const getVariantClassNames = ({ variant }: { variant: Variant }) => {
   return cx({
     'text-alert bg-white hover:text-alert active:text-white active:bg-alert focus-visible:text-alert':
       variant === 'destructive',
-    'text-primary-gray bg-white': variant === 'normal',
+    'text-black bg-white': variant === 'normal',
   });
 };
 

--- a/lib/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.tsx.snap
+++ b/lib/components/ConfirmDialog/__snapshots__/ConfirmDialog.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`ConfirmDialog > renders dialog when showDialog is called 1`] = `
             class="flex flex-row gap-5 px-6 py-5 sm:px-9"
           >
             <button
-              class="group flex select-none items-center gap-4 rounded-[30px] px-6 text-button-md hover:text-accent focus-visible:text-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-accent active:bg-accent active:text-white active:outline-0 text-primary-gray bg-white"
+              class="group flex select-none items-center gap-4 rounded-[30px] px-6 text-button-md hover:text-accent focus-visible:text-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-accent active:bg-accent active:text-white active:outline-0 text-black bg-white"
             >
               <span
                 class="py-[10px] group-hover:underline group-focus-visible:no-underline group-active:no-underline"
@@ -64,7 +64,7 @@ exports[`ConfirmDialog > renders dialog when showDialog is called 1`] = `
               </span>
             </button>
             <button
-              class="group flex select-none items-center gap-4 rounded-[30px] px-6 text-button-md hover:text-accent focus-visible:text-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-accent active:bg-accent active:text-white active:outline-0 text-primary-gray bg-white"
+              class="group flex select-none items-center gap-4 rounded-[30px] px-6 text-button-md hover:text-accent focus-visible:text-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-accent active:bg-accent active:text-white active:outline-0 text-black bg-white"
             >
               <span
                 class="py-[10px] group-hover:underline group-focus-visible:no-underline group-active:no-underline"

--- a/lib/components/Datepicker/Datepicker.tsx
+++ b/lib/components/Datepicker/Datepicker.tsx
@@ -66,7 +66,7 @@ export const Datepicker = React.forwardRef<HTMLInputElement, DatepickerProps>(fu
       className="w-full"
       isDateUnavailable={(date) => isInvalidYear(date.year)}
     >
-      <ArkDatePicker.Label className="mb-4 inline-block align-top text-form-label text-primary-gray">
+      <ArkDatePicker.Label className="mb-4 inline-block align-top text-form-label text-black">
         {label}
       </ArkDatePicker.Label>
       <ArkDatePicker.Control>
@@ -75,7 +75,7 @@ export const Datepicker = React.forwardRef<HTMLInputElement, DatepickerProps>(fu
             ref={ref}
             name={name}
             placeholder={placeholder ? `(${placeholder})` : undefined}
-            className="w-full rounded-l-[10px] border-y-[5px] border-l-[5px] border-border-gray bg-white p-[11px] text-primary-gray outline-none placeholder:text-secondary-gray"
+            className="w-full rounded-l-[10px] border-y-[5px] border-l-[5px] border-border-gray bg-white p-[11px] text-black outline-none placeholder:text-secondary-gray"
             onInput={(e: React.ChangeEvent<HTMLInputElement>) => {
               if (e.target.value === '') {
                 onChange({

--- a/lib/components/Datepicker/__snapshots__/Datepicker.test.tsx.snap
+++ b/lib/components/Datepicker/__snapshots__/Datepicker.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Datepicker > renders correctly 1`] = `
   id="datepicker::r1:"
 >
   <label
-    class="mb-4 inline-block align-top text-form-label text-primary-gray"
+    class="mb-4 inline-block align-top text-form-label text-black"
     data-part="label"
     data-scope="date-picker"
     data-state="closed"
@@ -31,7 +31,7 @@ exports[`Datepicker > renders correctly 1`] = `
       <input
         autocomplete="off"
         autocorrect="off"
-        class="w-full rounded-l-[10px] border-y-[5px] border-l-[5px] border-border-gray bg-white p-[11px] text-primary-gray outline-none placeholder:text-secondary-gray"
+        class="w-full rounded-l-[10px] border-y-[5px] border-l-[5px] border-border-gray bg-white p-[11px] text-black outline-none placeholder:text-secondary-gray"
         data-part="input"
         data-scope="date-picker"
         data-state="closed"

--- a/lib/components/InputField/InputField.tsx
+++ b/lib/components/InputField/InputField.tsx
@@ -25,7 +25,7 @@ export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(fu
   const helpId = React.useId();
   return (
     <>
-      <label htmlFor={inputId} className="mb-4 inline-block align-top text-form-label text-primary-gray">
+      <label htmlFor={inputId} className="mb-4 inline-block align-top text-form-label text-black">
         {label}
       </label>
       <input
@@ -39,7 +39,7 @@ export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(fu
         placeholder={placeholder ? `(${placeholder})` : undefined}
         autoComplete="off"
         aria-describedby={help ? helpId : undefined}
-        className="block w-full rounded-[10px] border-[5px] border-border-gray bg-white p-[11px] text-primary-gray outline-none placeholder:text-secondary-gray"
+        className="block w-full rounded-[10px] border-[5px] border-border-gray bg-white p-[11px] text-black outline-none placeholder:text-secondary-gray"
       />
       {help && (
         <div id={helpId} className="mt-2 block text-help text-secondary-3">

--- a/lib/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/lib/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InputField > renders help text correctly 1`] = `
 <label
-  class="mb-4 inline-block align-top text-form-label text-primary-gray"
+  class="mb-4 inline-block align-top text-form-label text-black"
   for=":r4:"
 >
   Username
@@ -11,7 +11,7 @@ exports[`InputField > renders help text correctly 1`] = `
 
 exports[`InputField > renders input correctly 1`] = `
 <label
-  class="mb-4 inline-block align-top text-form-label text-primary-gray"
+  class="mb-4 inline-block align-top text-form-label text-black"
   for=":r2:"
 >
   Username
@@ -20,7 +20,7 @@ exports[`InputField > renders input correctly 1`] = `
 
 exports[`InputField > renders label correctly 1`] = `
 <label
-  class="mb-4 inline-block align-top text-form-label text-primary-gray"
+  class="mb-4 inline-block align-top text-form-label text-black"
   for=":r0:"
 >
   Username
@@ -29,7 +29,7 @@ exports[`InputField > renders label correctly 1`] = `
 
 exports[`InputField > updates input value correctly 1`] = `
 <label
-  class="mb-4 inline-block align-top text-form-label text-primary-gray"
+  class="mb-4 inline-block align-top text-form-label text-black"
   for=":r6:"
 >
   Username

--- a/lib/components/Modal/Modal.stories.tsx
+++ b/lib/components/Modal/Modal.stories.tsx
@@ -62,7 +62,7 @@ const render = (args: Story['args']) => {
 const Button = ({ label, onClick }: { label: string; onClick?: () => void }) => {
   return (
     <button
-      className="group flex select-none items-center gap-4 rounded-[30px] bg-white px-6 text-button-md text-primary-gray hover:text-accent focus-visible:text-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-accent active:bg-accent active:text-white active:outline-0"
+      className="group flex select-none items-center gap-4 rounded-[30px] bg-white px-6 text-button-md text-black hover:text-accent focus-visible:text-accent focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-accent active:bg-accent active:text-white active:outline-0"
       onClick={onClick}
     >
       <span className="py-[10px] group-hover:underline group-focus-visible:no-underline group-active:no-underline">

--- a/lib/components/NavigationBar/NavigationBar.stories.tsx
+++ b/lib/components/NavigationBar/NavigationBar.stories.tsx
@@ -81,8 +81,8 @@ const login: NavigationBarProps['login'] = {
 
 const logo = (
   <a href="/" className="flex">
-    <div className="inline-flex select-none items-center gap-4 text-[24px] leading-[140%] text-accent">
-      <div className="h-8 w-8 bg-accent"></div>JOD
+    <div className="inline-flex select-none items-center gap-4 text-[24px] leading-[140%] text-black">
+      <div className="h-8 w-8 bg-secondary-gray"></div>JOD
     </div>
   </a>
 );

--- a/lib/components/NavigationBar/NavigationBar.tsx
+++ b/lib/components/NavigationBar/NavigationBar.tsx
@@ -53,7 +53,7 @@ export const NavigationBar = ({ logo, items, user, login }: NavigationBarProps) 
             <li key={item.key}>
               <item.component
                 aria-current={item.active ? 'location' : undefined}
-                className={`flex items-center gap-3 rounded-lg px-5 py-2 ${item.active ? 'text-accent' : 'text-primary-gray'}`}
+                className={`flex items-center gap-3 rounded-lg px-5 py-2 ${item.active ? 'text-accent' : 'text-black'}`}
               >
                 {item.active && <ActiveIndicator />}
                 {item.text}
@@ -75,7 +75,7 @@ export const NavigationBar = ({ logo, items, user, login }: NavigationBarProps) 
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="80 -880 800 800"
-                  className="rounded-full fill-primary-gray"
+                  className="rounded-full fill-black"
                   role="img"
                   aria-label={login.text}
                 >

--- a/lib/components/NavigationBar/__snapshots__/NavigationBar.test.tsx.snap
+++ b/lib/components/NavigationBar/__snapshots__/NavigationBar.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`NavigationBar > renders navigation items and user 1`] = `
       </li>
       <li>
         <a
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-primary-gray"
+          class="flex items-center gap-3 rounded-lg px-5 py-2 text-black"
           href="/about"
         >
           About
@@ -47,7 +47,7 @@ exports[`NavigationBar > renders navigation items and user 1`] = `
       </li>
       <li>
         <a
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-primary-gray"
+          class="flex items-center gap-3 rounded-lg px-5 py-2 text-black"
           href="/contact"
         >
           Contact
@@ -94,7 +94,7 @@ exports[`NavigationBar > renders no navigation items and no user 1`] = `
         >
           <svg
             aria-label="Login"
-            class="rounded-full fill-primary-gray"
+            class="rounded-full fill-black"
             role="img"
             viewBox="80 -880 800 800"
             xmlns="http://www.w3.org/2000/svg"
@@ -149,7 +149,7 @@ exports[`NavigationBar > renders only navigation items 1`] = `
       </li>
       <li>
         <a
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-primary-gray"
+          class="flex items-center gap-3 rounded-lg px-5 py-2 text-black"
           href="/about"
         >
           About
@@ -157,7 +157,7 @@ exports[`NavigationBar > renders only navigation items 1`] = `
       </li>
       <li>
         <a
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-primary-gray"
+          class="flex items-center gap-3 rounded-lg px-5 py-2 text-black"
           href="/contact"
         >
           Contact
@@ -172,7 +172,7 @@ exports[`NavigationBar > renders only navigation items 1`] = `
         >
           <svg
             aria-label="Login"
-            class="rounded-full fill-primary-gray"
+            class="rounded-full fill-black"
             role="img"
             viewBox="80 -880 800 800"
             xmlns="http://www.w3.org/2000/svg"

--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -2,7 +2,7 @@ import { Pagination as ArkPagination, PaginationRootProps } from '@ark-ui/react'
 import { cx } from '../../cva';
 
 const getClassName = ({ isActive = false, isArrowButton = true, disabled = false } = {}) =>
-  cx(`min-w-7 min-h-7 p-2 rounded-full text-button-smflex bg-bg-gray text-primary-gray`, {
+  cx(`min-w-7 min-h-7 p-2 rounded-full text-button-smflex bg-bg-gray text-black`, {
     'bg-accent text-white': !isArrowButton && isActive,
     'material-symbols-outlined': isArrowButton,
     'disabled:text-inactive-gray disabled:cursor-not-allowed': disabled === true,

--- a/lib/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   id="pagination::r1:"
 >
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray material-symbols-outlined disabled:text-inactive-gray disabled:cursor-not-allowed"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black material-symbols-outlined disabled:text-inactive-gray disabled:cursor-not-allowed"
     disabled=""
     type="button"
   >
@@ -26,7 +26,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   </button>
   <button
     aria-label="Previous"
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray material-symbols-outlined disabled:text-inactive-gray disabled:cursor-not-allowed"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black material-symbols-outlined disabled:text-inactive-gray disabled:cursor-not-allowed"
     data-disabled=""
     data-part="prev-trigger"
     data-scope="pagination"
@@ -60,7 +60,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     1
   </button>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray font-bold"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black font-bold"
     data-index="2"
     data-part="item"
     data-scope="pagination"
@@ -71,7 +71,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     2
   </button>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray font-bold"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black font-bold"
     data-index="3"
     data-part="item"
     data-scope="pagination"
@@ -82,7 +82,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     3
   </button>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray font-bold"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black font-bold"
     data-index="4"
     data-part="item"
     data-scope="pagination"
@@ -93,7 +93,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     4
   </button>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray font-bold"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black font-bold"
     data-index="5"
     data-part="item"
     data-scope="pagination"
@@ -104,7 +104,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     5
   </button>
   <div
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray material-symbols-outlined"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black material-symbols-outlined"
     data-part="ellipsis"
     data-scope="pagination"
     dir="ltr"
@@ -117,7 +117,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     </span>
   </div>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray font-bold"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black font-bold"
     data-index="10"
     data-part="item"
     data-scope="pagination"
@@ -129,7 +129,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   </button>
   <button
     aria-label="Next"
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray material-symbols-outlined"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black material-symbols-outlined"
     data-part="next-trigger"
     data-scope="pagination"
     dir="ltr"
@@ -148,7 +148,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     </span>
   </button>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray material-symbols-outlined"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black material-symbols-outlined"
     type="button"
   >
     <span
@@ -174,7 +174,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   id="pagination::r0:"
 >
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray material-symbols-outlined disabled:text-inactive-gray disabled:cursor-not-allowed"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black material-symbols-outlined disabled:text-inactive-gray disabled:cursor-not-allowed"
     disabled=""
     type="button"
   >
@@ -191,7 +191,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   </button>
   <button
     aria-label="Previous"
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray material-symbols-outlined disabled:text-inactive-gray disabled:cursor-not-allowed"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black material-symbols-outlined disabled:text-inactive-gray disabled:cursor-not-allowed"
     data-disabled=""
     data-part="prev-trigger"
     data-scope="pagination"
@@ -225,7 +225,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     1
   </button>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray font-bold"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black font-bold"
     data-index="2"
     data-part="item"
     data-scope="pagination"
@@ -236,7 +236,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     2
   </button>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray font-bold"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black font-bold"
     data-index="3"
     data-part="item"
     data-scope="pagination"
@@ -247,7 +247,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     3
   </button>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray font-bold"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black font-bold"
     data-index="4"
     data-part="item"
     data-scope="pagination"
@@ -259,7 +259,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   </button>
   <button
     aria-label="Next"
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray material-symbols-outlined"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black material-symbols-outlined"
     data-part="next-trigger"
     data-scope="pagination"
     dir="ltr"
@@ -278,7 +278,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     </span>
   </button>
   <button
-    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-primary-gray material-symbols-outlined"
+    class="min-w-7 min-h-7 p-2 rounded-full bg-bg-gray text-black material-symbols-outlined"
     type="button"
   >
     <span

--- a/lib/components/RadioButton/RadioButton.tsx
+++ b/lib/components/RadioButton/RadioButton.tsx
@@ -15,7 +15,7 @@ export const RadioButton = ({ label, value, className }: RadioButtonProps) => {
       {({ checked }) => (
         <div className="flex-start flex space-x-4">
           {checked ? <CheckedIcon /> : <UncheckedIcon />}
-          <span className="flex items-center text-button-md text-primary-gray hover:text-accent hover:underline hyphens-auto">
+          <span className="flex items-center text-button-md text-black hover:text-accent hover:underline hyphens-auto">
             {label}
           </span>
         </div>
@@ -49,7 +49,7 @@ const UncheckedIcon = () => {
       fill="none"
       className="self-center"
     >
-      <circle cx="12.0352" cy="12.0389" r="11" className="stroke-primary-gray" strokeWidth="2" />
+      <circle cx="12.0352" cy="12.0389" r="11" className="stroke-black" strokeWidth="2" />
     </svg>
   );
 };

--- a/lib/components/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/lib/components/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Snapshot testing > Default 1`] = `
         />
       </svg>
       <span
-        class="flex items-center text-button-md text-primary-gray hover:text-accent hover:underline hyphens-auto"
+        class="flex items-center text-button-md text-black hover:text-accent hover:underline hyphens-auto"
       >
         A
       </span>

--- a/lib/components/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/lib/components/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Snapshot testing > Default 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <circle
-          class="stroke-primary-gray"
+          class="stroke-black"
           cx="12.0352"
           cy="12.0389"
           r="11"
@@ -42,7 +42,7 @@ exports[`Snapshot testing > Default 1`] = `
         />
       </svg>
       <span
-        class="flex items-center text-button-md text-primary-gray hover:text-accent hover:underline hyphens-auto"
+        class="flex items-center text-button-md text-black hover:text-accent hover:underline hyphens-auto"
       >
         Option 1
       </span>

--- a/lib/components/ResultsCard/ResultsCard.tsx
+++ b/lib/components/ResultsCard/ResultsCard.tsx
@@ -11,8 +11,8 @@ export interface ResultsCardProps {
 export const ResultsCard = ({ value, label }: ResultsCardProps) => {
   return (
     <div className="flex w-min flex-col-reverse items-center rounded-[10px] bg-bg-gray px-8 py-5 font-bold">
-      <span className="text-heading-4 text-primary-gray">{label}</span>
-      <span className="text-[80px] leading-[110%] text-primary-gray">{value}</span>
+      <span className="text-heading-4 text-black">{label}</span>
+      <span className="text-[80px] leading-[110%] text-black">{value}</span>
     </div>
   );
 };

--- a/lib/components/ResultsCard/__snapshots__/ResultsCard.test.tsx.snap
+++ b/lib/components/ResultsCard/__snapshots__/ResultsCard.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`ResultsCard > renders the text and the label 1`] = `
   class="flex w-min flex-col-reverse items-center rounded-[10px] bg-bg-gray px-8 py-5 font-bold"
 >
   <span
-    class="text-heading-4 text-primary-gray"
+    class="text-heading-4 text-black"
   >
     Dolor sit amet
   </span>
   <span
-    class="text-[80px] leading-[110%] text-primary-gray"
+    class="text-[80px] leading-[110%] text-black"
   >
     Lorem ipsum
   </span>

--- a/lib/components/RoundButton/RoundButton.tsx
+++ b/lib/components/RoundButton/RoundButton.tsx
@@ -34,12 +34,12 @@ export const RoundButton = ({
     >
       <span
         aria-hidden
-        className={`size-[72px] rounded-full ${selected ? 'bg-accent' : 'bg-bg-gray'} flex items-center justify-center ${selected ? 'text-white' : 'text-primary-gray hover:text-accent'} material-symbols-outlined size-48 select-none`}
+        className={`size-[72px] rounded-full ${selected ? 'bg-accent' : 'bg-bg-gray'} flex items-center justify-center ${selected ? 'text-white' : 'text-black hover:text-accent'} material-symbols-outlined size-48 select-none`}
       >
         {icon}
       </span>
       <span
-        className={`${hideLabel ? 'hidden' : ''} text-button-sm ${selected ? 'text-accent' : 'text-primary-gray'} group-hover:text-accent group-hover:underline`.trim()}
+        className={`${hideLabel ? 'hidden' : ''} text-button-sm ${selected ? 'text-accent' : 'text-black'} group-hover:text-accent group-hover:underline`.trim()}
       >
         {label}
       </span>

--- a/lib/components/RoundButton/__snapshots__/RoundButton.test.tsx.snap
+++ b/lib/components/RoundButton/__snapshots__/RoundButton.test.tsx.snap
@@ -8,12 +8,12 @@ exports[`Snapshot testing > Default 1`] = `
 >
   <span
     aria-hidden="true"
-    class="size-[72px] rounded-full bg-bg-gray flex items-center justify-center text-primary-gray hover:text-accent material-symbols-outlined size-48 select-none"
+    class="size-[72px] rounded-full bg-bg-gray flex items-center justify-center text-black hover:text-accent material-symbols-outlined size-48 select-none"
   >
     target
   </span>
   <span
-    class="text-button-sm text-primary-gray group-hover:text-accent group-hover:underline"
+    class="text-button-sm text-black group-hover:text-accent group-hover:underline"
   >
     Default
   </span>
@@ -28,12 +28,12 @@ exports[`Snapshot testing > Disabled, non-selected 1`] = `
 >
   <span
     aria-hidden="true"
-    class="size-[72px] rounded-full bg-bg-gray flex items-center justify-center text-primary-gray hover:text-accent material-symbols-outlined size-48 select-none"
+    class="size-[72px] rounded-full bg-bg-gray flex items-center justify-center text-black hover:text-accent material-symbols-outlined size-48 select-none"
   >
     target
   </span>
   <span
-    class="text-button-sm text-primary-gray group-hover:text-accent group-hover:underline"
+    class="text-button-sm text-black group-hover:text-accent group-hover:underline"
   >
     Disabled, non-selected
   </span>

--- a/lib/components/RoundLinkButton/RoundLinkButton.tsx
+++ b/lib/components/RoundLinkButton/RoundLinkButton.tsx
@@ -36,12 +36,12 @@ export const RoundLinkButton = ({
     >
       <span
         aria-hidden
-        className={`${selected ? 'text-white' : 'text-primary-gray'} material-symbols-outlined size-48 group- flex size-[64px] select-none items-center justify-center self-center rounded-full ${selected ? 'bg-accent' : 'bg-bg-gray hover:text-accent'}`}
+        className={`${selected ? 'text-white' : 'text-black'} material-symbols-outlined size-48 group- flex size-[64px] select-none items-center justify-center self-center rounded-full ${selected ? 'bg-accent' : 'bg-bg-gray hover:text-accent'}`}
       >
         {icon}
       </span>
       <span
-        className={`${hideLabel ? 'hidden' : ''} text-button-sm ${selected ? 'text-accent' : 'text-primary-gray'} group-hover:text-accent group-hover:underline`.trim()}
+        className={`${hideLabel ? 'hidden' : ''} text-button-sm ${selected ? 'text-accent' : 'text-black'} group-hover:text-accent group-hover:underline`.trim()}
       >
         {label}
       </span>

--- a/lib/components/RoundLinkButton/__snapshots__/RoundLinkButton.test.tsx.snap
+++ b/lib/components/RoundLinkButton/__snapshots__/RoundLinkButton.test.tsx.snap
@@ -8,12 +8,12 @@ exports[`Snapshot testing > Default 1`] = `
 >
   <span
     aria-hidden="true"
-    class="text-primary-gray material-symbols-outlined size-48 group- flex size-[64px] select-none items-center justify-center self-center rounded-full bg-bg-gray hover:text-accent"
+    class="text-black material-symbols-outlined size-48 group- flex size-[64px] select-none items-center justify-center self-center rounded-full bg-bg-gray hover:text-accent"
   >
     target
   </span>
   <span
-    class="text-button-sm text-primary-gray group-hover:text-accent group-hover:underline"
+    class="text-button-sm text-black group-hover:text-accent group-hover:underline"
   >
     Default
   </span>
@@ -28,12 +28,12 @@ exports[`Snapshot testing > Disabled, non-selected 1`] = `
 >
   <span
     aria-hidden="true"
-    class="text-primary-gray material-symbols-outlined size-48 group- flex size-[64px] select-none items-center justify-center self-center rounded-full bg-bg-gray hover:text-accent"
+    class="text-black material-symbols-outlined size-48 group- flex size-[64px] select-none items-center justify-center self-center rounded-full bg-bg-gray hover:text-accent"
   >
     target
   </span>
   <span
-    class="text-button-sm text-primary-gray group-hover:text-accent group-hover:underline"
+    class="text-button-sm text-black group-hover:text-accent group-hover:underline"
   >
     Disabled, nonselected
   </span>

--- a/lib/components/Slider/Slider.tsx
+++ b/lib/components/Slider/Slider.tsx
@@ -89,7 +89,7 @@ export const Slider = ({ label, icon, onValueChange, value }: SliderProps) => {
   return (
     <div className="flex h-[63px] w-full rounded-[100px] bg-bg-gray">
       <span
-        className={`m-2 size-[55px] rounded-full ${focused ? 'bg-accent' : 'bg-white'} flex items-center justify-center ${focused ? 'text-white' : 'text-primary-gray'} material-symbols-outlined select-none`}
+        className={`m-2 size-[55px] rounded-full ${focused ? 'bg-accent' : 'bg-white'} flex items-center justify-center ${focused ? 'text-white' : 'text-black'} material-symbols-outlined select-none`}
         aria-hidden
       >
         <span className="flex items-center justify-center text-[37px]">{icon}</span>
@@ -118,7 +118,7 @@ export const Slider = ({ label, icon, onValueChange, value }: SliderProps) => {
       {focused && (
         <div
           ref={refs.setFloating}
-          className="max-w-[292px] rounded-[20px] bg-primary-gray px-[20px] py-2 text-button-md text-white sm:text-body-md"
+          className="max-w-[292px] rounded-[20px] bg-black px-[20px] py-2 text-button-md text-white sm:text-body-md"
           style={floatingStyles}
           {...getFloatingProps()}
         >
@@ -126,7 +126,7 @@ export const Slider = ({ label, icon, onValueChange, value }: SliderProps) => {
           <FloatingArrow
             ref={arrowRef}
             context={context}
-            className="fill-primary-gray"
+            className="fill-black"
             width={ARROW_HEIGHT * 2}
             height={ARROW_HEIGHT}
           />

--- a/lib/components/TagsInput/TagsInput.tsx
+++ b/lib/components/TagsInput/TagsInput.tsx
@@ -35,7 +35,7 @@ export const TagsInput = ({ label, placeholder, tags, onValueChange, inputPositi
       <ArkTagsInput.Context>
         {(tagsInput) => (
           <>
-            <ArkTagsInput.Label className="mb-4 text-form-label text-primary-gray">{label}</ArkTagsInput.Label>
+            <ArkTagsInput.Label className="mb-4 text-form-label text-black">{label}</ArkTagsInput.Label>
             <div
               className={`${tagsInput.value.length > 0 ? 'gap-3' : ''} flex flex-col rounded-[10px] border-[5px] border-border-gray p-5`.trim()}
             >

--- a/lib/components/TagsInput/__snapshots__/TagsInput.test.tsx.snap
+++ b/lib/components/TagsInput/__snapshots__/TagsInput.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Snapshot testing > matches the snapshot 1`] = `
     id="tags-input::r0:"
   >
     <label
-      class="mb-4 text-form-label text-primary-gray"
+      class="mb-4 text-form-label text-black"
       data-part="label"
       data-scope="tags-input"
       dir="ltr"

--- a/lib/components/Tooltip/TooltipContent.tsx
+++ b/lib/components/Tooltip/TooltipContent.tsx
@@ -14,7 +14,7 @@ export const TooltipContent = React.forwardRef<HTMLDivElement, React.HTMLProps<H
     return (
       <FloatingPortal>
         <div
-          className="max-w-[292px] rounded-[20px] bg-primary-gray px-6 py-5 text-body-sm text-white sm:text-body-md"
+          className="max-w-[292px] rounded-[20px] bg-black px-6 py-5 text-body-sm text-white sm:text-body-md"
           ref={ref}
           style={{
             ...tooltipContext.floatingStyles,
@@ -25,7 +25,7 @@ export const TooltipContent = React.forwardRef<HTMLDivElement, React.HTMLProps<H
           <FloatingArrow
             ref={tooltipContext.arrowRef}
             context={tooltipContext.context}
-            className="fill-primary-gray"
+            className="fill-black"
             width={ARROW_HEIGHT * 2}
             height={ARROW_HEIGHT}
           />

--- a/lib/components/WizardProgress/WizardProgress.tsx
+++ b/lib/components/WizardProgress/WizardProgress.tsx
@@ -12,7 +12,7 @@ export interface WizardProgressProps {
 /** A component that displays the progress of a wizard. */
 export const WizardProgress = ({ steps, currentStep, completedText, currentText }: WizardProgressProps) => {
   return (
-    <ol className="flex gap-4 text-body-md font-bold text-primary-gray sm:text-body-lg sm:font-bold">
+    <ol className="flex gap-4 text-body-md font-bold text-black sm:text-body-lg sm:font-bold">
       {Array.from({ length: steps }, (_, index) => (
         <li
           key={index + 1}

--- a/lib/components/WizardProgress/__snapshots__/WizardProgress.test.tsx.snap
+++ b/lib/components/WizardProgress/__snapshots__/WizardProgress.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`WizardProgress > renders correctly 1`] = `
 <ol
-  class="flex gap-4 text-body-md font-bold text-primary-gray sm:text-body-lg sm:font-bold"
+  class="flex gap-4 text-body-md font-bold text-black sm:text-body-lg sm:font-bold"
 >
   <li
     class="flex min-h-7 min-w-7 items-center justify-center rounded-full bg-bg-gray sm:min-h-8 sm:min-w-8"


### PR DESCRIPTION
## Description

Replaced "primary-gray" with "black" in CSS classes, as "primary-gray" has been removed

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-540
