### PR TITLE
OPHJOD-565: Update NavigationBar to match with new design

### DIFF
--- a/lib/components/NavigationBar/NavigationBar.stories.tsx
+++ b/lib/components/NavigationBar/NavigationBar.stories.tsx
@@ -22,49 +22,6 @@ const parameters = {
   },
 };
 
-const items: NavigationBarProps['items'] = [
-  {
-    key: 'yksiloille',
-    text: 'Yksilöille',
-    active: true,
-    component: ({ children, ...rootProps }) => (
-      <a href="/yksiloille" {...rootProps}>
-        {children}
-      </a>
-    ),
-  },
-  {
-    key: 'ohjaajille',
-    text: 'Ohjaajille',
-    active: false,
-    component: ({ children, ...rootProps }) => (
-      <a href="/ohjaajille" {...rootProps}>
-        {children}
-      </a>
-    ),
-  },
-  {
-    key: 'kouluttajille',
-    text: 'Kouluttajille',
-    active: false,
-    component: ({ children, ...rootProps }) => (
-      <a href="/kouluttajille" {...rootProps}>
-        {children}
-      </a>
-    ),
-  },
-  {
-    key: 'viranomaisille',
-    text: 'Viranomaisille',
-    active: false,
-    component: ({ children, ...rootProps }) => (
-      <a href="/viranomaisille" {...rootProps}>
-        {children}
-      </a>
-    ),
-  },
-];
-
 const user: NavigationBarProps['user'] = {
   name: 'Reetta Räppänä',
   component: ({ children, ...rootProps }) => (
@@ -89,7 +46,6 @@ const logo = (
 
 const args: NavigationBarProps = {
   logo,
-  items,
   user,
   login,
 };
@@ -99,7 +55,7 @@ export const Default: Story = {
     ...parameters,
     docs: {
       description: {
-        story: 'This story demonstrates how the navigation bar looks with navigation items and an avatar.',
+        story: 'This story demonstrates how the navigation bar looks with an avatar.',
       },
     },
   },
@@ -111,44 +67,12 @@ export const Plain: Story = {
     ...parameters,
     docs: {
       description: {
-        story: 'This story demonstrates how the navigation bar looks without any items or an avatar.',
+        story: 'This story demonstrates how the navigation bar looks without an avatar.',
       },
     },
   },
   args: {
     logo,
-    login,
-  },
-};
-
-export const Items: Story = {
-  parameters: {
-    ...parameters,
-    docs: {
-      description: {
-        story: 'This story demonstrates how the navigation bar looks with navigation items.',
-      },
-    },
-  },
-  args: {
-    logo,
-    items,
-    login,
-  },
-};
-
-export const Avatar: Story = {
-  parameters: {
-    ...parameters,
-    docs: {
-      description: {
-        story: 'This story demonstrates how the navigation bar looks with an avatar.',
-      },
-    },
-  },
-  args: {
-    logo,
-    user,
     login,
   },
 };

--- a/lib/components/NavigationBar/NavigationBar.test.tsx
+++ b/lib/components/NavigationBar/NavigationBar.test.tsx
@@ -7,37 +7,6 @@ import { NavigationBar, NavigationBarLinkProps } from './NavigationBar';
 describe('NavigationBar', () => {
   const logo = <div>logo</div>;
 
-  const items = [
-    {
-      key: 'home',
-      text: 'Home',
-      active: true,
-      href: '/home',
-    },
-    {
-      key: 'about',
-      text: 'About',
-      active: false,
-      href: '/about',
-    },
-    {
-      key: 'contact',
-      text: 'Contact',
-      active: false,
-      href: '/contact',
-    },
-  ].map(({ key, text, active, href }) => ({
-    key,
-    text,
-    active,
-    href,
-    component: ({ children, ...rootProps }: NavigationBarLinkProps) => (
-      <a href={href} {...rootProps}>
-        {children}
-      </a>
-    ),
-  }));
-
   const user = {
     name: 'Reetta Räppänä',
     component: ({ children, ...rootProps }: NavigationBarLinkProps) => (
@@ -49,42 +18,6 @@ describe('NavigationBar', () => {
 
   const login = { url: '/login', text: 'Login' };
 
-  it('renders navigation items and user', () => {
-    const { container } = render(<NavigationBar logo={logo} items={items} user={user} login={login} />);
-
-    // Assert snapshot
-    expect(container.firstChild).toMatchSnapshot();
-
-    // Assert navigation items
-    items.forEach((item) => {
-      const linkElement = screen.getByText(item.text);
-      expect(linkElement).toBeInTheDocument();
-      expect(linkElement).toHaveAttribute('href', item.href);
-    });
-
-    // Assert user
-    const userAvatar = screen.queryByTitle(user.name);
-    expect(userAvatar).toBeInTheDocument();
-  });
-
-  it('renders only navigation items', () => {
-    const { container } = render(<NavigationBar logo={logo} items={items} login={login} />);
-
-    // Assert snapshot
-    expect(container.firstChild).toMatchSnapshot();
-
-    // Assert navigation items
-    items.forEach((item) => {
-      const linkElement = screen.getByText(item.text);
-      expect(linkElement).toBeInTheDocument();
-      expect(linkElement).toHaveAttribute('href', item.href);
-    });
-
-    // Assert user is not rendered
-    const userAvatar = screen.queryByTitle(user.name);
-    expect(userAvatar).toBeNull();
-  });
-
   it('renders only user', () => {
     const { container } = render(<NavigationBar logo={logo} user={user} login={login} />);
 
@@ -94,12 +27,6 @@ describe('NavigationBar', () => {
     // Assert user
     const userAvatar = screen.queryByTitle(user.name);
     expect(userAvatar).toBeInTheDocument();
-
-    // Assert navigation items are not rendered
-    items.forEach((item) => {
-      const linkElement = screen.queryByText(item.text);
-      expect(linkElement).toBeNull();
-    });
   });
 
   it('renders no navigation items and no user', () => {
@@ -108,14 +35,15 @@ describe('NavigationBar', () => {
     // Assert snapshot
     expect(container.firstChild).toMatchSnapshot();
 
-    // Assert navigation items are not rendered
-    items.forEach((item) => {
-      const linkElement = screen.queryByText(item.text);
-      expect(linkElement).toBeNull();
-    });
-
     // Assert user is not rendered
     const userAvatar = screen.queryByTitle(user.name);
     expect(userAvatar).toBeNull();
+  });
+
+  it('renders menu component', () => {
+    const menuComponent = <div>Menu</div>;
+    render(<NavigationBar logo={logo} menuComponent={menuComponent} login={login} />);
+    const menuComponentElement = screen.getByText('Menu');
+    expect(menuComponentElement).toBeInTheDocument();
   });
 });

--- a/lib/components/NavigationBar/NavigationBar.tsx
+++ b/lib/components/NavigationBar/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import { ActiveIndicator } from '../ActiveIndicator/ActiveIndicator';
+import { useMediaQueries } from '../../hooks/useMediaQueries';
 
 export interface NavigationBarLinkProps {
   className?: string;
@@ -12,13 +12,8 @@ export type NavigationBarLink = React.ComponentType<NavigationBarLinkProps>;
 export interface NavigationBarProps {
   /** Navigation logo */
   logo: React.ReactNode;
-  /** Navigation items */
-  items?: {
-    key: React.Key;
-    text: string;
-    active: boolean;
-    component: NavigationBarLink;
-  }[];
+  /** Place for menu opener button */
+  menuComponent?: React.ReactNode;
   /** Navigation avatar */
   user?: {
     name: string;
@@ -31,9 +26,11 @@ export interface NavigationBarProps {
 }
 
 /**
- * This component is a navigation bar that displays a logo, navigation items, and an avatar.
+ * This component is a navigation bar that displays a logo, and an avatar.
  */
-export const NavigationBar = ({ logo, items, user, login }: NavigationBarProps) => {
+export const NavigationBar = ({ logo, menuComponent, user, login }: NavigationBarProps) => {
+  const { sm } = useMediaQueries();
+
   const initials = user?.name
     .split(' ')
     .map((part) => part[0])
@@ -42,48 +39,34 @@ export const NavigationBar = ({ logo, items, user, login }: NavigationBarProps) 
     .toUpperCase();
 
   return (
-    <div className="min-w-min border-b-[4px] border-inactive-gray bg-[#FFFFFFE5]">
+    <div className="min-w-min shadow-border bg-white">
       <nav
         role="navigation"
-        className="mx-auto flex h-[68px] items-center justify-between gap-4 px-[72px] py-[14px] font-semibold lg:container"
+        className="mx-auto flex h-[56px] items-center justify-between gap-4 px-7 py-3 font-semibold lg:container"
       >
         {logo}
-        <ul className="inline-flex items-center gap-6">
-          {items?.map((item) => (
-            <li key={item.key}>
-              <item.component
-                aria-current={item.active ? 'location' : undefined}
-                className={`flex items-center gap-3 rounded-lg px-5 py-2 ${item.active ? 'text-accent' : 'text-black'}`}
-              >
-                {item.active && <ActiveIndicator />}
-                {item.text}
-              </item.component>
-            </li>
-          ))}
-          <li className="ml-6">
+        <ul className="inline-flex items-center gap-3 sm:gap-5">
+          {menuComponent && sm && <li>{menuComponent}</li>}
+          {/** TODO: Language selection */}
+          <li className="ml-5 flex h-8 w-8 items-center justify-center rounded-full bg-bg-gray-2">
+            <span className="material-symbols-outlined size-24 select-none text-black">language</span>
+          </li>
+          <li>
             {user ? (
               <user.component
-                className="flex h-8 w-8 items-center justify-center rounded-full bg-accent text-white"
+                className="flex h-8 w-8 items-center justify-center rounded-full bg-secondary-3 text-white"
                 role="img"
                 title={user.name}
               >
                 {initials}
               </user.component>
             ) : (
-              <a href={login.url} className="flex h-8 w-8 items-center justify-center rounded-full">
-                {/* Copyright 2020 Google LLC; http://www.apache.org/licenses/LICENSE-2.0 */}
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="80 -880 800 800"
-                  className="rounded-full fill-black"
-                  role="img"
-                  aria-label={login.text}
-                >
-                  <path d="M222-255q63-44 125-67.5T480-346q71 0 133.5 23.5T739-255q44-54 62.5-109T820-480q0-145-97.5-242.5T480-820q-145 0-242.5 97.5T140-480q0 61 19 116t63 109Zm257.81-195q-57.81 0-97.31-39.69-39.5-39.68-39.5-97.5 0-57.81 39.69-97.31 39.68-39.5 97.5-39.5 57.81 0 97.31 39.69 39.5 39.68 39.5 97.5 0 57.81-39.69 97.31-39.68 39.5-97.5 39.5Zm.66 370Q398-80 325-111.5t-127.5-86q-54.5-54.5-86-127.27Q80-397.53 80-480.27 80-563 111.5-635.5q31.5-72.5 86-127t127.27-86q72.76-31.5 155.5-31.5 82.73 0 155.23 31.5 72.5 31.5 127 86t86 127.03q31.5 72.53 31.5 155T848.5-325q-31.5 73-86 127.5t-127.03 86Q562.94-80 480.47-80Zm-.47-60q55 0 107.5-16T691-212q-51-36-104-55t-107-19q-54 0-107 19t-104 55q51 40 103.5 56T480-140Zm0-370q34 0 55.5-21.5T557-587q0-34-21.5-55.5T480-664q-34 0-55.5 21.5T403-587q0 34 21.5 55.5T480-510Zm0-77Zm0 374Z" />
-                </svg>
+              <a href={login.url} className="flex h-8 w-8 items-center justify-center rounded-full bg-bg-gray-2">
+                <span className="material-symbols-outlined size-24 select-none text-black">person</span>
               </a>
             )}
           </li>
+          {menuComponent && !sm && <li className="ml-3">{menuComponent}</li>}
         </ul>
       </nav>
     </div>

--- a/lib/components/NavigationBar/__snapshots__/NavigationBar.test.tsx.snap
+++ b/lib/components/NavigationBar/__snapshots__/NavigationBar.test.tsx.snap
@@ -1,186 +1,38 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`NavigationBar > renders navigation items and user 1`] = `
-<div
-  class="min-w-min border-b-[4px] border-inactive-gray bg-[#FFFFFFE5]"
->
-  <nav
-    class="mx-auto flex h-[68px] items-center justify-between gap-4 px-[72px] py-[14px] font-semibold lg:container"
-    role="navigation"
-  >
-    <div>
-      logo
-    </div>
-    <ul
-      class="inline-flex items-center gap-6"
-    >
-      <li>
-        <a
-          aria-current="location"
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-accent"
-          href="/home"
-        >
-          <svg
-            aria-hidden="true"
-            class="absolute -ml-6"
-            focusable="false"
-            height="15"
-            width="15"
-          >
-            <circle
-              class="fill-accent"
-              cx="7.5"
-              cy="7.5"
-              r="7.5"
-            />
-          </svg>
-          Home
-        </a>
-      </li>
-      <li>
-        <a
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-black"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-black"
-          href="/contact"
-        >
-          Contact
-        </a>
-      </li>
-      <li
-        class="ml-6"
-      >
-        <a
-          aria-label="Profile"
-          class="flex h-8 w-8 items-center justify-center rounded-full bg-accent text-white"
-          href="/profile"
-          role="img"
-          title="Reetta Räppänä"
-        >
-          RR
-        </a>
-      </li>
-    </ul>
-  </nav>
-</div>
-`;
-
 exports[`NavigationBar > renders no navigation items and no user 1`] = `
 <div
-  class="min-w-min border-b-[4px] border-inactive-gray bg-[#FFFFFFE5]"
+  class="min-w-min shadow-border bg-white"
 >
   <nav
-    class="mx-auto flex h-[68px] items-center justify-between gap-4 px-[72px] py-[14px] font-semibold lg:container"
+    class="mx-auto flex h-[56px] items-center justify-between gap-4 px-7 py-3 font-semibold lg:container"
     role="navigation"
   >
     <div>
       logo
     </div>
     <ul
-      class="inline-flex items-center gap-6"
+      class="inline-flex items-center gap-3 sm:gap-5"
     >
       <li
-        class="ml-6"
+        class="ml-5 flex h-8 w-8 items-center justify-center rounded-full bg-bg-gray-2"
       >
+        <span
+          class="material-symbols-outlined size-24 select-none text-black"
+        >
+          language
+        </span>
+      </li>
+      <li>
         <a
-          class="flex h-8 w-8 items-center justify-center rounded-full"
+          class="flex h-8 w-8 items-center justify-center rounded-full bg-bg-gray-2"
           href="/login"
         >
-          <svg
-            aria-label="Login"
-            class="rounded-full fill-black"
-            role="img"
-            viewBox="80 -880 800 800"
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            class="material-symbols-outlined size-24 select-none text-black"
           >
-            <path
-              d="M222-255q63-44 125-67.5T480-346q71 0 133.5 23.5T739-255q44-54 62.5-109T820-480q0-145-97.5-242.5T480-820q-145 0-242.5 97.5T140-480q0 61 19 116t63 109Zm257.81-195q-57.81 0-97.31-39.69-39.5-39.68-39.5-97.5 0-57.81 39.69-97.31 39.68-39.5 97.5-39.5 57.81 0 97.31 39.69 39.5 39.68 39.5 97.5 0 57.81-39.69 97.31-39.68 39.5-97.5 39.5Zm.66 370Q398-80 325-111.5t-127.5-86q-54.5-54.5-86-127.27Q80-397.53 80-480.27 80-563 111.5-635.5q31.5-72.5 86-127t127.27-86q72.76-31.5 155.5-31.5 82.73 0 155.23 31.5 72.5 31.5 127 86t86 127.03q31.5 72.53 31.5 155T848.5-325q-31.5 73-86 127.5t-127.03 86Q562.94-80 480.47-80Zm-.47-60q55 0 107.5-16T691-212q-51-36-104-55t-107-19q-54 0-107 19t-104 55q51 40 103.5 56T480-140Zm0-370q34 0 55.5-21.5T557-587q0-34-21.5-55.5T480-664q-34 0-55.5 21.5T403-587q0 34 21.5 55.5T480-510Zm0-77Zm0 374Z"
-            />
-          </svg>
-        </a>
-      </li>
-    </ul>
-  </nav>
-</div>
-`;
-
-exports[`NavigationBar > renders only navigation items 1`] = `
-<div
-  class="min-w-min border-b-[4px] border-inactive-gray bg-[#FFFFFFE5]"
->
-  <nav
-    class="mx-auto flex h-[68px] items-center justify-between gap-4 px-[72px] py-[14px] font-semibold lg:container"
-    role="navigation"
-  >
-    <div>
-      logo
-    </div>
-    <ul
-      class="inline-flex items-center gap-6"
-    >
-      <li>
-        <a
-          aria-current="location"
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-accent"
-          href="/home"
-        >
-          <svg
-            aria-hidden="true"
-            class="absolute -ml-6"
-            focusable="false"
-            height="15"
-            width="15"
-          >
-            <circle
-              class="fill-accent"
-              cx="7.5"
-              cy="7.5"
-              r="7.5"
-            />
-          </svg>
-          Home
-        </a>
-      </li>
-      <li>
-        <a
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-black"
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li>
-        <a
-          class="flex items-center gap-3 rounded-lg px-5 py-2 text-black"
-          href="/contact"
-        >
-          Contact
-        </a>
-      </li>
-      <li
-        class="ml-6"
-      >
-        <a
-          class="flex h-8 w-8 items-center justify-center rounded-full"
-          href="/login"
-        >
-          <svg
-            aria-label="Login"
-            class="rounded-full fill-black"
-            role="img"
-            viewBox="80 -880 800 800"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M222-255q63-44 125-67.5T480-346q71 0 133.5 23.5T739-255q44-54 62.5-109T820-480q0-145-97.5-242.5T480-820q-145 0-242.5 97.5T140-480q0 61 19 116t63 109Zm257.81-195q-57.81 0-97.31-39.69-39.5-39.68-39.5-97.5 0-57.81 39.69-97.31 39.68-39.5 97.5-39.5 57.81 0 97.31 39.69 39.5 39.68 39.5 97.5 0 57.81-39.69 97.31-39.68 39.5-97.5 39.5Zm.66 370Q398-80 325-111.5t-127.5-86q-54.5-54.5-86-127.27Q80-397.53 80-480.27 80-563 111.5-635.5q31.5-72.5 86-127t127.27-86q72.76-31.5 155.5-31.5 82.73 0 155.23 31.5 72.5 31.5 127 86t86 127.03q31.5 72.53 31.5 155T848.5-325q-31.5 73-86 127.5t-127.03 86Q562.94-80 480.47-80Zm-.47-60q55 0 107.5-16T691-212q-51-36-104-55t-107-19q-54 0-107 19t-104 55q51 40 103.5 56T480-140Zm0-370q34 0 55.5-21.5T557-587q0-34-21.5-55.5T480-664q-34 0-55.5 21.5T403-587q0 34 21.5 55.5T480-510Zm0-77Zm0 374Z"
-            />
-          </svg>
+            person
+          </span>
         </a>
       </li>
     </ul>
@@ -190,24 +42,31 @@ exports[`NavigationBar > renders only navigation items 1`] = `
 
 exports[`NavigationBar > renders only user 1`] = `
 <div
-  class="min-w-min border-b-[4px] border-inactive-gray bg-[#FFFFFFE5]"
+  class="min-w-min shadow-border bg-white"
 >
   <nav
-    class="mx-auto flex h-[68px] items-center justify-between gap-4 px-[72px] py-[14px] font-semibold lg:container"
+    class="mx-auto flex h-[56px] items-center justify-between gap-4 px-7 py-3 font-semibold lg:container"
     role="navigation"
   >
     <div>
       logo
     </div>
     <ul
-      class="inline-flex items-center gap-6"
+      class="inline-flex items-center gap-3 sm:gap-5"
     >
       <li
-        class="ml-6"
+        class="ml-5 flex h-8 w-8 items-center justify-center rounded-full bg-bg-gray-2"
       >
+        <span
+          class="material-symbols-outlined size-24 select-none text-black"
+        >
+          language
+        </span>
+      </li>
+      <li>
         <a
           aria-label="Profile"
-          class="flex h-8 w-8 items-center justify-center rounded-full bg-accent text-white"
+          class="flex h-8 w-8 items-center justify-center rounded-full bg-secondary-3 text-white"
           href="/profile"
           role="img"
           title="Reetta Räppänä"


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Update to match with new design
- Removed `items` prop
  - Items are no longer in the bar itself, but will be in the opened MegaMenu
- On mobile, the placement of MegaMenu opener is in different location than on desktop. At the end on mobile; at the start on desktop.
- Added a placeholder icon/place for the language change functionality to easily adjust the spacings/margins between items.

## Screenshots

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/00053853-4168-4b04-a348-e1b150126074">


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-565
