### PR TITLE
OPHJOD-603: Use component instead of a link in Note read more button

### DIFF
--- a/lib/components/Note/Note.stories.tsx
+++ b/lib/components/Note/Note.stories.tsx
@@ -45,8 +45,7 @@ export const ConfirmationNote: Story = {
   args: {
     title,
     description,
-    readMoreText: 'Lue lisää',
-    readMoreHref: '/',
+    readMoreComponent: <>Lue lisää</>,
     onCloseClick: fn(),
   },
 };
@@ -71,8 +70,7 @@ export const LongTitleText: Story = {
   args: {
     title: 'Lorem ipsum dolor est nonummy noblem ester!',
     description,
-    readMoreText: 'Lue lisää',
-    readMoreHref: '/',
+    readMoreComponent: <>Lue lisää</>,
     onCloseClick: fn(),
   },
 };
@@ -97,8 +95,7 @@ export const PermanentNote: Story = {
   args: {
     title,
     description,
-    readMoreText: 'Lue lisää',
-    readMoreHref: '/',
+    readMoreComponent: <>Lue lisää</>,
   },
 };
 

--- a/lib/components/Note/Note.test.tsx
+++ b/lib/components/Note/Note.test.tsx
@@ -36,19 +36,12 @@ describe('Note component', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders with read more link', () => {
+  it('renders with read more component', () => {
     const { container } = render(
-      <Note
-        title="Test Title"
-        description="Test Description"
-        variant="success"
-        readMoreText="Read more"
-        readMoreHref="/"
-      />,
+      <Note title="Test Title" description="Test Description" variant="success" readMoreComponent={<>Read more</>} />,
     );
-    const readMoreLink = screen.getByRole('button', { name: 'Read more' });
+    const readMoreLink = screen.getByText(/Read more/);
     expect(readMoreLink).toBeInTheDocument();
-    expect(readMoreLink).toHaveAttribute('href', '/');
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/lib/components/Note/Note.tsx
+++ b/lib/components/Note/Note.tsx
@@ -10,22 +10,13 @@ export interface NoteProps {
   variant?: 'success' | 'warning' | 'error';
   /** Callback fired on tap/click of the close button */
   onCloseClick?: () => void;
-  /** Text for read more link if variant is success */
-  readMoreText?: string;
-  /** Link to read more if variant is success */
-  readMoreHref?: string;
+  /** Component inside the button container if variant is success */
+  readMoreComponent?: React.ReactNode;
 }
 
-export const Note = ({
-  title,
-  description,
-  variant = 'success',
-  onCloseClick,
-  readMoreText,
-  readMoreHref,
-}: NoteProps) => {
+export const Note = ({ title, description, variant = 'success', onCloseClick, readMoreComponent }: NoteProps) => {
   const { sm } = useMediaQueries();
-  const hasReadMore = variant === 'success' && readMoreText && readMoreHref;
+  const hasReadMore = variant === 'success' && readMoreComponent;
   return (
     <div
       role="alert"
@@ -42,24 +33,16 @@ export const Note = ({
           <div className="font-poppins text-heading-4 sm:text-heading-3">{title}</div>
           <div className="mt-1 sm:mt-0 text-body-sm">{description}</div>
           {hasReadMore && !sm && (
-            <a
-              className="font-poppins mt-4 text-nowrap rounded-[30px] bg-white px-6 py-[10px] text-button-md hover:underline focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-white active:bg-accent active:text-white active:no-underline"
-              href={readMoreHref}
-              role="button"
-            >
-              {readMoreText}
-            </a>
+            <span className="font-poppins mt-4 text-nowrap rounded-[30px] bg-white px-6 py-[10px] text-button-md hover:underline focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-white active:bg-accent active:text-white active:no-underline">
+              {readMoreComponent}
+            </span>
           )}
         </div>
         <div className="flex items-center">
           {hasReadMore && sm && (
-            <a
-              className="font-poppins mx-7 text-nowrap rounded-[30px] bg-white px-6 py-[10px] text-button-md hover:underline focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-white active:bg-accent active:text-white active:no-underline"
-              href={readMoreHref}
-              role="button"
-            >
-              {readMoreText}
-            </a>
+            <span className="font-poppins mx-7 text-nowrap rounded-[30px] bg-white px-6 py-[10px] text-button-md hover:underline focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-white active:bg-accent active:text-white active:no-underline">
+              {readMoreComponent}
+            </span>
           )}
           {onCloseClick && (
             <button

--- a/lib/components/Note/__snapshots__/Note.test.tsx.snap
+++ b/lib/components/Note/__snapshots__/Note.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`Note component > renders with error variant 1`] = `
 </div>
 `;
 
-exports[`Note component > renders with read more link 1`] = `
+exports[`Note component > renders with read more component 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
@@ -128,13 +128,11 @@ exports[`Note component > renders with read more link 1`] = `
       >
         Test Description
       </div>
-      <a
+      <span
         class="font-poppins mt-4 text-nowrap rounded-[30px] bg-white px-6 py-[10px] text-button-md hover:underline focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-[1.5px] focus-visible:outline-white active:bg-accent active:text-white active:no-underline"
-        href="/"
-        role="button"
       >
         Read more
-      </a>
+      </span>
     </div>
     <div
       class="flex items-center"


### PR DESCRIPTION
## Description
* `href` and `readMoreText` props are replaced with `readMoreComponent` in `Note` component. Done to prevent full page reload when clicking the provided link. Now it's possible to use `<NavLink>` or similar in `Note` to use react router.

> [!NOTE]
> Read more functionality hasn't been used yet in yksilö UI, so no changes required there.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-603
