### PR TITLE
OPHJOD-634: Add size and bgColor props to RoundButton

### DIFF
--- a/lib/components/RoundButton/RoundButton.tsx
+++ b/lib/components/RoundButton/RoundButton.tsx
@@ -1,3 +1,5 @@
+import { tidyClasses } from '../../utils';
+
 export interface RoundButtonProps {
   /** Text shown on the button */
   label: string;
@@ -13,6 +15,10 @@ export interface RoundButtonProps {
   className?: string;
   /** Icon name from Material Design */
   icon: string;
+  /** Icon size: sm = 32px, md = 40px, lg = 64px  */
+  size?: 'sm' | 'md' | 'lg';
+  /** Background color */
+  bgColor?: 'gray' | 'white';
 }
 
 /** Round button component for single-step user actions. */
@@ -24,26 +30,73 @@ export const RoundButton = ({
   selected = false,
   className,
   icon,
+  size = 'md',
+  bgColor = 'gray',
 }: RoundButtonProps) => {
+  const buttonSizeClass = tidyClasses(`
+    ${size === 'sm' ? 'ds-size-[32px]' : ''}
+    ${size === 'md' ? 'ds-size-[40px]' : ''}
+    ${size === 'lg' ? 'ds-size-[64px]' : ''}
+  `);
+
+  const iconSizeClass = tidyClasses(`
+    ${size === 'sm' ? 'size-26' : ''}
+    ${size === 'md' ? 'size-32' : ''}
+    ${size === 'lg' ? 'size-48' : ''}
+  `);
+
+  const bgColorClass = tidyClasses(`
+    ${!selected && bgColor === 'gray' ? 'ds-bg-bg-gray-2' : ''}
+    ${!selected && bgColor === 'white' ? 'ds-bg-white' : ''}
+  `);
+
   return (
     <button
       aria-label={label}
       disabled={disabled}
       type="button"
       onClick={onClick}
-      className={`${className ? className : ''} ds-group ds-flex ds-flex-col ds-justify-center ${disabled ? 'ds-cursor-not-allowed ds-opacity-50' : ''} ds-min-w-[110px] ds-items-center ds-gap-2`.trim()}
+      className={tidyClasses(`
+        ${className ?? ''}
+        ${disabled ? 'ds-cursor-not-allowed ds-opacity-50' : ''}
+        ds-group
+        ds-flex
+        ds-flex-col
+        ds-justify-center 
+        ds-items-center
+        ds-gap-2
+      `)}
     >
-      <span
+      <div
         aria-hidden
-        className={`ds-size-[72px] ds-rounded-full ${selected ? 'ds-bg-accent ds-text-white' : 'ds-bg-bg-gray-2 ds-text-black group-hover:ds-text-accent'} ds-flex ds-items-center ds-justify-center material-symbols-outlined size-48 ds-select-none`}
+        className={tidyClasses(`
+          ${buttonSizeClass}
+          ${selected ? 'ds-bg-accent' : bgColorClass}
+          ${selected ? 'ds-text-white' : 'ds-text-black group-hover:ds-text-accent'}
+          ds-rounded-full
+          ds-flex
+          ds-items-center
+          ds-justify-center
+          ds-select-none
+      `)}
       >
-        {icon}
-      </span>
-      <span
-        className={`${hideLabel ? 'ds-hidden' : ''} ds-text-button-sm ${selected ? 'ds-text-accent' : 'ds-text-black'} group-hover:ds-text-accent group-hover:ds-underline`.trim()}
-      >
-        {label}
-      </span>
+        <span className={`${iconSizeClass} material-symbols-outlined`}>{icon}</span>
+      </div>
+      <LabelPart label={label} hideLabel={hideLabel} selected={selected} />
     </button>
   );
 };
+
+const LabelPart = ({ label, hideLabel, selected }: Pick<RoundButtonProps, 'label' | 'hideLabel' | 'selected'>) => (
+  <span
+    className={tidyClasses(`
+      ${hideLabel ? 'ds-hidden' : ''}
+      ${selected ? 'ds-text-accent' : 'ds-text-black'}
+      ds-text-button-sm
+      group-hover:ds-text-accent
+      group-hover:ds-underline
+    `)}
+  >
+    {label}
+  </span>
+);

--- a/lib/components/RoundButton/__snapshots__/RoundButton.test.tsx.snap
+++ b/lib/components/RoundButton/__snapshots__/RoundButton.test.tsx.snap
@@ -3,17 +3,21 @@
 exports[`Snapshot testing > Default 1`] = `
 <button
   aria-label="Default"
-  class="ds-group ds-flex ds-flex-col ds-justify-center  ds-min-w-[110px] ds-items-center ds-gap-2"
+  class="ds-group ds-flex ds-flex-col ds-justify-center ds-items-center ds-gap-2"
   type="button"
 >
-  <span
+  <div
     aria-hidden="true"
-    class="ds-size-[72px] ds-rounded-full ds-bg-bg-gray-2 ds-text-black group-hover:ds-text-accent ds-flex ds-items-center ds-justify-center material-symbols-outlined size-48 ds-select-none"
+    class="ds-size-[40px] ds-bg-bg-gray-2 ds-text-black group-hover:ds-text-accent ds-rounded-full ds-flex ds-items-center ds-justify-center ds-select-none"
   >
-    target
-  </span>
+    <span
+      class="size-32 material-symbols-outlined"
+    >
+      target
+    </span>
+  </div>
   <span
-    class="ds-text-button-sm ds-text-black group-hover:ds-text-accent group-hover:ds-underline"
+    class="ds-text-black ds-text-button-sm group-hover:ds-text-accent group-hover:ds-underline"
   >
     Default
   </span>
@@ -23,17 +27,21 @@ exports[`Snapshot testing > Default 1`] = `
 exports[`Snapshot testing > Disabled, non-selected 1`] = `
 <button
   aria-label="Disabled, non-selected"
-  class="ds-group ds-flex ds-flex-col ds-justify-center  ds-min-w-[110px] ds-items-center ds-gap-2"
+  class="ds-group ds-flex ds-flex-col ds-justify-center ds-items-center ds-gap-2"
   type="button"
 >
-  <span
+  <div
     aria-hidden="true"
-    class="ds-size-[72px] ds-rounded-full ds-bg-bg-gray-2 ds-text-black group-hover:ds-text-accent ds-flex ds-items-center ds-justify-center material-symbols-outlined size-48 ds-select-none"
+    class="ds-size-[40px] ds-bg-bg-gray-2 ds-text-black group-hover:ds-text-accent ds-rounded-full ds-flex ds-items-center ds-justify-center ds-select-none"
   >
-    target
-  </span>
+    <span
+      class="size-32 material-symbols-outlined"
+    >
+      target
+    </span>
+  </div>
   <span
-    class="ds-text-button-sm ds-text-black group-hover:ds-text-accent group-hover:ds-underline"
+    class="ds-text-black ds-text-button-sm group-hover:ds-text-accent group-hover:ds-underline"
   >
     Disabled, non-selected
   </span>
@@ -43,17 +51,21 @@ exports[`Snapshot testing > Disabled, non-selected 1`] = `
 exports[`Snapshot testing > Disabled, selected 1`] = `
 <button
   aria-label="Disabled, non-selected"
-  class="ds-group ds-flex ds-flex-col ds-justify-center  ds-min-w-[110px] ds-items-center ds-gap-2"
+  class="ds-group ds-flex ds-flex-col ds-justify-center ds-items-center ds-gap-2"
   type="button"
 >
-  <span
+  <div
     aria-hidden="true"
-    class="ds-size-[72px] ds-rounded-full ds-bg-accent ds-text-white ds-flex ds-items-center ds-justify-center material-symbols-outlined size-48 ds-select-none"
+    class="ds-size-[40px] ds-bg-accent ds-text-white ds-rounded-full ds-flex ds-items-center ds-justify-center ds-select-none"
   >
-    target
-  </span>
+    <span
+      class="size-32 material-symbols-outlined"
+    >
+      target
+    </span>
+  </div>
   <span
-    class="ds-text-button-sm ds-text-accent group-hover:ds-text-accent group-hover:ds-underline"
+    class="ds-text-accent ds-text-button-sm group-hover:ds-text-accent group-hover:ds-underline"
   >
     Disabled, non-selected
   </span>
@@ -63,17 +75,21 @@ exports[`Snapshot testing > Disabled, selected 1`] = `
 exports[`Snapshot testing > Disabled, selected 2`] = `
 <button
   aria-label="Disabled, non-selected"
-  class="ds-group ds-flex ds-flex-col ds-justify-center  ds-min-w-[110px] ds-items-center ds-gap-2"
+  class="ds-group ds-flex ds-flex-col ds-justify-center ds-items-center ds-gap-2"
   type="button"
 >
-  <span
+  <div
     aria-hidden="true"
-    class="ds-size-[72px] ds-rounded-full ds-bg-accent ds-text-white ds-flex ds-items-center ds-justify-center material-symbols-outlined size-48 ds-select-none"
+    class="ds-size-[40px] ds-bg-accent ds-text-white ds-rounded-full ds-flex ds-items-center ds-justify-center ds-select-none"
   >
-    target
-  </span>
+    <span
+      class="size-32 material-symbols-outlined"
+    >
+      target
+    </span>
+  </div>
   <span
-    class="ds-text-button-sm ds-text-accent group-hover:ds-text-accent group-hover:ds-underline"
+    class="ds-text-accent ds-text-button-sm group-hover:ds-text-accent group-hover:ds-underline"
   >
     Disabled, non-selected
   </span>
@@ -83,17 +99,21 @@ exports[`Snapshot testing > Disabled, selected 2`] = `
 exports[`Snapshot testing > selected 1`] = `
 <button
   aria-label="Selected"
-  class="ds-group ds-flex ds-flex-col ds-justify-center  ds-min-w-[110px] ds-items-center ds-gap-2"
+  class="ds-group ds-flex ds-flex-col ds-justify-center ds-items-center ds-gap-2"
   type="button"
 >
-  <span
+  <div
     aria-hidden="true"
-    class="ds-size-[72px] ds-rounded-full ds-bg-accent ds-text-white ds-flex ds-items-center ds-justify-center material-symbols-outlined size-48 ds-select-none"
+    class="ds-size-[40px] ds-bg-accent ds-text-white ds-rounded-full ds-flex ds-items-center ds-justify-center ds-select-none"
   >
-    target
-  </span>
+    <span
+      class="size-32 material-symbols-outlined"
+    >
+      target
+    </span>
+  </div>
   <span
-    class="ds-text-button-sm ds-text-accent group-hover:ds-text-accent group-hover:ds-underline"
+    class="ds-text-accent ds-text-button-sm group-hover:ds-text-accent group-hover:ds-underline"
   >
     Selected
   </span>


### PR DESCRIPTION
## Description

* Added `size` and `bgColor` props to RoundButton
* Move the Label part into own component, because Sonar complained about cognitive complexity.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-634
