### PR TITLE
OPHJOD-705: Add rightLabel prop for Slider

### DIFF
--- a/lib/components/Slider/Slider.stories.tsx
+++ b/lib/components/Slider/Slider.stories.tsx
@@ -64,3 +64,23 @@ export const Default: Story = {
     value: 50,
   },
 };
+
+export const WithRightLabel: Story = {
+  render,
+  decorators: [
+    (Story) => (
+      <div className="ds-max-w-[348px]">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    ...parameters,
+  },
+  args: {
+    label: 'Osaamiset',
+    rightLabel: 'Kiinnostukset',
+    onValueChange: fn(),
+    value: 50,
+  },
+};

--- a/lib/components/Slider/Slider.test.tsx
+++ b/lib/components/Slider/Slider.test.tsx
@@ -28,7 +28,7 @@ describe('Slider', () => {
     render(<Slider label="Target" onValueChange={onValueChangeMock} value={0} />);
 
     const [sliderThumb] = screen.getAllByRole('slider', { hidden: true });
-    sliderThumb.focus();
+    await waitFor(() => sliderThumb.focus());
 
     await user.keyboard('[ArrowRight]');
     expect(sliderThumb).toHaveAttribute('aria-valuenow', '25');
@@ -36,5 +36,24 @@ describe('Slider', () => {
     expect(sliderThumb).toHaveAttribute('aria-valuenow', '0');
 
     await waitFor(() => expect(onValueChangeMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('should show both values in tooltip when rightLabel is used', async () => {
+    const rightLabel = 'Kiinnostukset';
+
+    render(<Slider label="Osaamiset" value={25} onValueChange={vi.fn()} rightLabel={rightLabel} />);
+
+    const [sliderThumb] = screen.getAllByRole('slider', { hidden: true });
+    await waitFor(() => sliderThumb.focus());
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('75 - 25 %');
+  });
+
+  it('should render the label and rightLabel correctly', () => {
+    render(<Slider label="Osaamiset" rightLabel="Kiinnostukset" onValueChange={() => vi.fn()} value={50} />);
+
+    expect(screen.getByText('Osaamiset')).toBeInTheDocument();
+    expect(screen.getByText('Kiinnostukset')).toBeInTheDocument();
   });
 });

--- a/lib/components/Slider/Slider.tsx
+++ b/lib/components/Slider/Slider.tsx
@@ -19,12 +19,16 @@ import {
 } from '@floating-ui/react';
 import React from 'react';
 
+import { tidyClasses as tc } from '../../utils';
+
 const ARROW_HEIGHT = 12;
 const GAP = 8;
 
 export interface SliderProps {
   /** Label */
   label: string;
+  /** Label to right side */
+  rightLabel?: string;
   /** On slider value change */
   onValueChange: (value: number) => void;
   /** Current value of the slider */
@@ -40,7 +44,7 @@ const Marker = () => {
 };
 
 /** Sliders allow users to quickly select a value within a range. They should be used when the upper and lower bounds to the range are invariable. */
-export const Slider = ({ label, onValueChange, value }: SliderProps) => {
+export const Slider = ({ label, onValueChange, value, rightLabel }: SliderProps) => {
   const inputId = React.useId();
   const [focused, setFocused] = React.useState(false);
   const arrowRef = React.useRef(null);
@@ -74,13 +78,20 @@ export const Slider = ({ label, onValueChange, value }: SliderProps) => {
     setFocused(details.focusedIndex === 0);
   };
 
+  const getTooltipValue = () => {
+    if (rightLabel) {
+      return `${100 - value} - ${value} %`;
+    }
+    return `${value} %`;
+  };
+
   return (
     <div className="ds-flex ds-h-[40px] ds-rounded-[20px] ds-bg-white ds-justify-between">
-      <span className="ds-ml-5 ds-flex ds-items-center ds-text-[12px] ds-basis-1/4">{label}</span>
+      <span className="ds-ml-6 ds-mr-5 ds-flex ds-items-center ds-text-[12px]">{label}</span>
       <ArkSlider.Root
         id={inputId}
         name={`slider-${inputId}`}
-        className="ds-ml-5 ds-mr-7 sm:ds-mr-5 ds-flex ds-grow ds-flex-col ds-justify-center ds-basis-3/4"
+        className={tc([rightLabel ? '' : 'ds-mr-6', 'ds-flex ds-grow ds-flex-col ds-justify-center'])}
         onValueChange={onValueChangeHandler}
         onFocusChange={onFocusChangeHandler}
         value={[value]}
@@ -115,6 +126,7 @@ export const Slider = ({ label, onValueChange, value }: SliderProps) => {
           />
         </ArkSlider.Control>
       </ArkSlider.Root>
+      {rightLabel && <span className="ds-ml-5 ds-mr-6 ds-flex ds-items-center ds-text-[12px]">{rightLabel}</span>}
       {focused && (
         <div
           ref={refs.setFloating}
@@ -122,7 +134,7 @@ export const Slider = ({ label, onValueChange, value }: SliderProps) => {
           style={floatingStyles}
           {...getFloatingProps()}
         >
-          {value}%
+          {getTooltipValue()}
           <FloatingArrow
             ref={arrowRef}
             context={context}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Add `rightLabel` prop for Slider
- Tooltip updated to have logic when `rightLabel` prop is given.
- Output value of the component is still same: from **0** to **100** range

## Screenshot


<img width="370" alt="Slider component showing the tooltip with both values; for left and right side" src="https://github.com/user-attachments/assets/5082df8d-9706-489e-8b5a-fd175ae10397">



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-705
