### PR TITLE
OPHJOD-794: Add presentation variant to Tag

### DIFF
--- a/lib/components/Tag/Tag.stories.tsx
+++ b/lib/components/Tag/Tag.stories.tsx
@@ -17,7 +17,7 @@ export const Selectable: Story = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=542-6833',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-6028',
     },
   },
   args: {
@@ -30,7 +30,7 @@ export const Selected: Story = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=542-6866',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-6042',
     },
   },
   args: {
@@ -38,5 +38,40 @@ export const Selected: Story = {
     onClick: fn(),
     variant: 'added',
     sourceType: 'tyopaikka',
+  },
+};
+
+export const Presentation: Story = {
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-6012&t=AyEPAtDzF6iKjlJw-4',
+    },
+  },
+  args: {
+    label: 'interesting',
+    variant: 'presentation',
+    sourceType: 'kiinnostus',
+  },
+};
+
+export const Multiline: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: '150px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-6095',
+    },
+  },
+  args: {
+    label: 'this should not fit on one line',
+    sourceType: 'rajoitus',
+    variant: 'presentation',
   },
 };

--- a/lib/components/Tag/Tag.test.tsx
+++ b/lib/components/Tag/Tag.test.tsx
@@ -22,4 +22,10 @@ describe('Tag', () => {
     fireEvent.click(getByRole('button'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it('should not be a button and no icons are present when using presentation variant', () => {
+    const { container, queryByRole } = render(<Tag label="presentation" variant="presentation" />);
+    expect(queryByRole('button')).toBeNull();
+    expect(container.querySelector('svg')).toBeNull();
+  });
 });

--- a/lib/components/Tag/Tag.tsx
+++ b/lib/components/Tag/Tag.tsx
@@ -1,31 +1,45 @@
 import { cx } from 'cva';
 import { MdAdd, MdClose } from 'react-icons/md';
 
-export interface TagProps {
+interface BaseTagProps {
   label: string;
-  onClick: () => void;
-  variant?: 'selectable' | 'added';
+  variant?: 'selectable' | 'added' | 'presentation';
   sourceType?: 'tyopaikka' | 'koulutus' | 'vapaa-ajan-toiminto' | 'kiinnostus' | 'jotain-muuta' | 'rajoitus';
 }
 
+interface PresentationTagProps extends BaseTagProps {
+  variant: 'presentation';
+  onClick?: never;
+}
+
+interface ActionableTagProps extends BaseTagProps {
+  variant?: 'selectable' | 'added';
+  onClick: () => void;
+}
+
+export type TagProps = PresentationTagProps | ActionableTagProps;
+
+const containerClassNames = (sourceType: TagProps['sourceType']) =>
+  cx(
+    'ds-group ds-inline-flex ds-select-none ds-items-center ds-rounded-xl ds-text-tag ds-font-arial ds-px-4 ds-py-2 ds-text-left',
+    {
+      'ds-bg-tag-tyopaikka': sourceType === 'tyopaikka',
+      'ds-bg-tag-koulutus': sourceType === 'koulutus',
+      'ds-bg-tag-vapaa-ajan-toiminto': sourceType === 'vapaa-ajan-toiminto',
+      'ds-bg-tag-jotain-muuta': sourceType === 'jotain-muuta',
+      'ds-bg-tag-kiinnostus': sourceType === 'kiinnostus',
+      'ds-bg-tag-rajoitus': sourceType === 'rajoitus',
+    },
+  );
+
 /** Tags allow users to categorize content. They can represent keywords or people, and are grouped to describe an item or a search request. */
 export const Tag = ({ label, onClick, variant = 'selectable', sourceType = 'jotain-muuta' }: TagProps) => {
-  return (
-    <button
-      type="button"
-      className={cx(
-        'ds-group ds-flex ds-select-none ds-items-center ds-rounded-xl ds-text-tag ds-font-arial ds-px-4 ds-py-2',
-        {
-          'ds-bg-tag-tyopaikka': sourceType === 'tyopaikka',
-          'ds-bg-tag-koulutus': sourceType === 'koulutus',
-          'ds-bg-tag-vapaa-ajan-toiminto': sourceType === 'vapaa-ajan-toiminto',
-          'ds-bg-tag-jotain-muuta': sourceType === 'jotain-muuta',
-          'ds-bg-tag-kiinnostus': sourceType === 'kiinnostus',
-          'ds-bg-tag-rajoitus': sourceType === 'rajoitus',
-        },
-      )}
-      onClick={onClick}
-    >
+  return variant === 'presentation' ? (
+    <span className={containerClassNames(sourceType)}>
+      <span className="ds-hyphens-auto ds-text-black">{label}</span>
+    </span>
+  ) : (
+    <button type="button" className={containerClassNames(sourceType)} onClick={onClick}>
       <span className="ds-hyphens-auto ds-text-black group-hover:ds-underline">{label}</span>
       <span className="ds-pl-3 ds-text-button-md ds-text-black" aria-hidden>
         {variant === 'selectable' ? <MdAdd size={16} /> : <MdClose size={16} />}

--- a/lib/components/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/lib/components/Tag/__snapshots__/Tag.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Snapshot testing > matches the snapshot 1`] = `
 <div>
   <button
-    class="ds-group ds-flex ds-select-none ds-items-center ds-rounded-xl ds-text-tag ds-font-arial ds-px-4 ds-py-2 ds-bg-tag-jotain-muuta"
+    class="ds-group ds-inline-flex ds-select-none ds-items-center ds-rounded-xl ds-text-tag ds-font-arial ds-px-4 ds-py-2 ds-text-left ds-bg-tag-jotain-muuta"
     type="button"
   >
     <span


### PR DESCRIPTION
## Description

* Add presentation variant to tag, that has no interactions
* Add story for a tag on multiple lines, as there's a design for it in Figma
* Updated design links in stories

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-794

![image](https://github.com/user-attachments/assets/e91a6890-65ce-4aa0-8dc0-1242e42ea8d5)

