### PR TITLE
OPHJOD-879: Fix storybook error with checkbox stories

### DIFF
--- a/lib/components/Checkbox/Checkbox.stories.tsx
+++ b/lib/components/Checkbox/Checkbox.stories.tsx
@@ -1,7 +1,6 @@
 import { action } from '@storybook/addon-actions';
-import { useArgs } from '@storybook/preview-api';
+import { useArgs, useState } from '@storybook/preview-api';
 import type { Meta, StoryObj } from '@storybook/react';
-import React from 'react';
 import { Checkbox, CheckboxProps } from './Checkbox';
 
 const meta = {
@@ -21,12 +20,7 @@ const design = {
 const label = 'Tuloksen sopivuus';
 const render = (args: CheckboxProps) => {
   const [, setArgs] = useArgs();
-  const [value, setValue] = React.useState<boolean>(args.checked);
-
-  React.useEffect(() => {
-    action('onChange')(args.checked);
-    setValue(args.checked);
-  }, [args.checked]);
+  const [value, setValue] = useState<boolean>(args.checked);
 
   const onChange = (value: boolean) => {
     action('onChange')(value);


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

* Fixed the `Storybook preview hooks can only be called inside decorators and story functions` error with checkbox stories. I'm not 100% sure what caused it, but using `useState` from `@storybook/preview-api` instead of React fixed the issue. I tried other components that used `React.useState` or `React.useEffect` but they didn't have any issues.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-879
