### PR TITLE
OPHJOD-874: Fix attrib-title to use px value for letterSpacing

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -105,7 +105,7 @@ export default {
       'button-sm': ['14px', { fontWeight: '600', lineHeight: '18px', letterSpacing: '0.28px' }], // Button S
       'button-sm-mobile': ['12px', { fontWeight: '600', lineHeight: '14px', letterSpacing: '0.28px' }], // Button S, mobile
       tag: ['14px', { fontWeight: '400', lineHeight: '20px' }], // Tag
-      'attrib-title': ['12px', { fontWeight: '400', lineHeight: '110%', letterSpacing: '1%' }], // Attribute title
+      'attrib-title': ['12px', { fontWeight: '400', lineHeight: '110%', letterSpacing: '0.12px' }], // Attribute title
       'attrib-value': ['12px', { fontWeight: '700', lineHeight: '110%', letterSpacing: '0.12px' }], // Attribute value
     },
     // https://www.figma.com/file/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=542%3A6656


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Fix `attrib-title` to use px value instead of percentage because percentages are not valid values in CSS for letter-spacing.
In this case **1%** => font size 12px/100 = **0.12px**

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-874
