### PR TITLE
OPHJOD-885: Update Pagination button size for desktop

### DIFF
--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -3,12 +3,15 @@ import { MdChevronLeft, MdChevronRight, MdMoreHoriz } from 'react-icons/md';
 import { cx } from '../../cva';
 
 const getClassName = ({ isActive = false, isArrowButton = true, disabled = false } = {}) =>
-  cx(`ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full`, {
-    'disabled:ds-text-inactive-gray disabled:ds-cursor-not-allowed': disabled === true,
-    'ds-bg-accent ds-text-white': !isArrowButton && isActive,
-    'ds-bg-bg-gray-2 ds-text-black': !isActive,
-    'ds-font-bold': !isArrowButton,
-  });
+  cx(
+    `sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center`,
+    {
+      'disabled:ds-text-inactive-gray disabled:ds-cursor-not-allowed': disabled === true,
+      'ds-bg-accent ds-text-white': !isArrowButton && isActive,
+      'ds-bg-bg-gray-2 ds-text-black': !isActive,
+      'ds-font-bold': !isArrowButton,
+    },
+  );
 
 export interface PaginationProps {
   totalItems: number;

--- a/lib/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/lib/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
 >
   <button
     aria-label="Previous"
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full disabled:ds-text-inactive-gray disabled:ds-cursor-not-allowed ds-bg-bg-gray-2 ds-text-black"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center disabled:ds-text-inactive-gray disabled:ds-cursor-not-allowed ds-bg-bg-gray-2 ds-text-black"
     data-disabled=""
     data-part="prev-trigger"
     data-scope="pagination"
@@ -39,7 +39,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   </button>
   <button
     aria-current="page"
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-accent ds-text-white ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-accent ds-text-white ds-font-bold"
     data-index="1"
     data-part="item"
     data-scope="pagination"
@@ -51,7 +51,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     1
   </button>
   <button
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black ds-font-bold"
     data-index="2"
     data-part="item"
     data-scope="pagination"
@@ -62,7 +62,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     2
   </button>
   <button
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black ds-font-bold"
     data-index="3"
     data-part="item"
     data-scope="pagination"
@@ -73,7 +73,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     3
   </button>
   <button
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black ds-font-bold"
     data-index="4"
     data-part="item"
     data-scope="pagination"
@@ -84,7 +84,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     4
   </button>
   <button
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black ds-font-bold"
     data-index="5"
     data-part="item"
     data-scope="pagination"
@@ -95,7 +95,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     5
   </button>
   <div
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black"
     data-part="ellipsis"
     data-scope="pagination"
     dir="ltr"
@@ -120,7 +120,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     </svg>
   </div>
   <button
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black ds-font-bold"
     data-index="10"
     data-part="item"
     data-scope="pagination"
@@ -132,7 +132,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   </button>
   <button
     aria-label="Next"
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black"
     data-part="next-trigger"
     data-scope="pagination"
     dir="ltr"
@@ -170,7 +170,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
 >
   <button
     aria-label="Previous"
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full disabled:ds-text-inactive-gray disabled:ds-cursor-not-allowed ds-bg-bg-gray-2 ds-text-black"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center disabled:ds-text-inactive-gray disabled:ds-cursor-not-allowed ds-bg-bg-gray-2 ds-text-black"
     data-disabled=""
     data-part="prev-trigger"
     data-scope="pagination"
@@ -199,7 +199,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   </button>
   <button
     aria-current="page"
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-accent ds-text-white ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-accent ds-text-white ds-font-bold"
     data-index="1"
     data-part="item"
     data-scope="pagination"
@@ -211,7 +211,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     1
   </button>
   <button
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black ds-font-bold"
     data-index="2"
     data-part="item"
     data-scope="pagination"
@@ -222,7 +222,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     2
   </button>
   <button
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black ds-font-bold"
     data-index="3"
     data-part="item"
     data-scope="pagination"
@@ -233,7 +233,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
     3
   </button>
   <button
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black ds-font-bold"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black ds-font-bold"
     data-index="4"
     data-part="item"
     data-scope="pagination"
@@ -245,7 +245,7 @@ exports[`Pagination > renders the pagination component with correct number of pa
   </button>
   <button
     aria-label="Next"
-    class="ds-min-w-7 ds-min-h-7 ds-p-2 ds-rounded-full ds-bg-bg-gray-2 ds-text-black"
+    class="sm:ds-min-w-[37px] ds-min-h-7 ds-min-w-7 sm:ds-min-h-[37px] ds-p-2 ds-rounded-full ds-flex ds-justify-center ds-items-center ds-bg-bg-gray-2 ds-text-black"
     data-part="next-trigger"
     data-scope="pagination"
     dir="ltr"


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Update the Pagination component page button size
  - Increase the size on desktop to match with the design, `37px`.
  - On mobile, left the size at the `32px` which both were previously; better
- Add centering to the classes as especially the ellipsis did go wonky after size increase when it was no longer centered

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-885
