### PR TITLE
OPHJOD-945: Update PageChangeDetails to be explicitly told

### DIFF
--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -13,7 +13,10 @@ const getClassName = ({ isActive = false, isArrowButton = true, disabled = false
     },
   );
 
-export type PageChangeDetails = ArkPagination.PageChangeDetails;
+export interface PageChangeDetails {
+  page: number;
+  pageSize: number;
+}
 
 export interface PaginationProps {
   totalItems: number;


### PR DESCRIPTION

<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Update `PageChangeDetails` to be explicitly told; not re-exported.

It seems that for some reason type checking still went to woods, what the previous fix #173 tried to already solve.


## More info

Explicitly now told the interface for `PageChangeDetails` as it seems that when it comes from the dependency's dependency it somehow goes wrong in the process when TypeScript/eslint is checking types.
This change just tells the same interface it should be deep down there.

Let's hope that this time it will work 🤞 

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-945
https://jira.eduuni.fi/browse/OPHJOD-861
