### PR TITLE
OPHJOD-1048: Fix contrast accessability issues in Slider component

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,7 +13,7 @@ module.exports = {
     'plugin:sonarjs/recommended-legacy',
     'prettier', // must be last, override other configs
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs', 'storybook-static', '!.storybook', '**.stories.tsx'],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'storybook-static', '!.storybook'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: ['./tsconfig.json', './tsconfig.node.json'],

--- a/lib/components/InputField/InputField.stories.tsx
+++ b/lib/components/InputField/InputField.stories.tsx
@@ -1,7 +1,6 @@
+import { useState } from '@storybook/preview-api';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
-import React from 'react';
-
 import { InputField } from './InputField';
 
 const meta = {
@@ -16,7 +15,7 @@ type Story = StoryObj<typeof meta>;
 
 const render = (args: Story['args']) => {
   const { value, onChange, ...rest } = args;
-  const [textValue, setTextValue] = React.useState(value);
+  const [textValue, setTextValue] = useState(value);
   return (
     <InputField
       value={textValue}

--- a/lib/components/Modal/Modal.stories.tsx
+++ b/lib/components/Modal/Modal.stories.tsx
@@ -22,6 +22,7 @@ const LoremIpsum = ({ heading }: { heading: string }) => {
       <p className="ds-font-bold">{heading}</p>
       <div className="ds-flex ds-flex-col ds-gap-4">
         {Array.from({ length: 10 }).map((_, index) => (
+          // eslint-disable-next-line sonarjs/no-array-index-key
           <p key={index}>{loremIpsumText}</p>
         ))}
       </div>

--- a/lib/components/SelectionCard/SelectionCard.stories.tsx
+++ b/lib/components/SelectionCard/SelectionCard.stories.tsx
@@ -1,6 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
-
 import { useState } from '@storybook/preview-api';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useMediaQueries } from '../../main';
 import { SelectionCard } from './SelectionCard';
 
@@ -67,6 +66,7 @@ export const MultipleWithHover: Story = {
     };
 
     const setInfoVisible = (index: number) => (visible: boolean) => {
+      // eslint-disable-next-line sonarjs/no-selector-parameter
       if (visible && info !== cardData[index].label) {
         setInfo(cardData[index].label);
       } else if (!visible) {
@@ -77,7 +77,7 @@ export const MultipleWithHover: Story = {
     const CardList = () =>
       cardData.map((card, index) => (
         <SelectionCard
-          key={index}
+          key={card.label}
           label={card.label}
           selected={card.selected}
           onClick={onClick(index)}

--- a/lib/components/Slider/Slider.stories.tsx
+++ b/lib/components/Slider/Slider.stories.tsx
@@ -1,4 +1,5 @@
 import { action } from '@storybook/addon-actions';
+import { useState } from '@storybook/preview-api';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import React from 'react';
@@ -14,9 +15,9 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const render = (args: Story['args']) => {
+const Render = (args: Story['args']) => {
   const { value, onValueChange, ...rest } = args;
-  const [numberValue, setNumberValue] = React.useState(value);
+  const [numberValue, setNumberValue] = useState(value);
 
   React.useEffect(() => {
     action('onValueChange')(args.value);
@@ -47,7 +48,7 @@ const parameters = {
 };
 
 export const Default: Story = {
-  render,
+  render: Render,
   decorators: [
     (Story) => (
       <div className="ds-max-w-[414px]">
@@ -66,7 +67,7 @@ export const Default: Story = {
 };
 
 export const WithRightLabel: Story = {
-  render,
+  render: Render,
   decorators: [
     (Story) => (
       <div className="ds-max-w-[348px]">
@@ -82,5 +83,26 @@ export const WithRightLabel: Story = {
     rightLabel: 'Kiinnostukset',
     onValueChange: fn(),
     value: 50,
+  },
+};
+
+export const Disabled: Story = {
+  render: Render,
+  decorators: [
+    (Story) => (
+      <div className="ds-max-w-[348px]">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    ...parameters,
+  },
+  args: {
+    label: 'Osaamiset',
+    rightLabel: 'Kiinnostukset',
+    onValueChange: fn(),
+    value: 50,
+    disabled: true,
   },
 };

--- a/lib/components/Slider/Slider.tsx
+++ b/lib/components/Slider/Slider.tsx
@@ -17,9 +17,8 @@ import {
   useInteractions,
   useRole,
 } from '@floating-ui/react';
-import React from 'react';
-
 import { cx } from 'cva';
+import React from 'react';
 import { tidyClasses as tc } from '../../utils';
 
 const ARROW_HEIGHT = 12;
@@ -88,75 +87,78 @@ export const Slider = ({ label, onValueChange, value, rightLabel, disabled }: Sl
 
   return (
     <div
-      className={cx(
-        'ds-flex ds-h-[40px] ds-rounded-[20px] ds-bg-white ds-justify-between ds:min-w-full sm:ds-min-w-[414px]',
-        {
-          'ds-text-inactive-gray ds-cursor-not-allowed': disabled,
-        },
-      )}
+      className={cx('ds-flex ds-h-[40px] ds-rounded-xl ds-bg-white ds-min-w-full sm:ds-min-w-[414px]', {
+        'ds-text-inactive-gray ds-cursor-not-allowed': disabled,
+      })}
     >
-      <span className="ds-ml-6 ds-mr-5 ds-flex ds-items-center ds-text-[12px]">{label}</span>
       <ArkSlider.Root
         id={inputId}
         name={`slider-${inputId}`}
-        className={tc([rightLabel ? '' : 'ds-mr-6', 'ds-flex ds-grow ds-flex-col ds-justify-center'])}
+        className={tc([rightLabel ? '' : 'ds-mr-6', 'ds-flex ds-flex-row ds-justify-between ds-w-full'])}
         onValueChange={onValueChangeHandler}
         onFocusChange={onFocusChangeHandler}
         value={[value]}
         step={25}
         disabled={disabled}
       >
-        <ArkSlider.MarkerGroup
-          className={cx('ds-z-10 ds-bg-todo', {
-            'ds-text-[#71A9CB]': !disabled,
-            'ds-text-inactive-gray': disabled,
-          })}
-        >
-          <ArkSlider.Marker value={0}>
-            <Marker />
-          </ArkSlider.Marker>
-          <ArkSlider.Marker value={25}>
-            <Marker />
-          </ArkSlider.Marker>
-          <ArkSlider.Marker value={50}>
-            <Marker />
-          </ArkSlider.Marker>
-          <ArkSlider.Marker value={75}>
-            <Marker />
-          </ArkSlider.Marker>
-          <ArkSlider.Marker value={100}>
-            <Marker />
-          </ArkSlider.Marker>
-        </ArkSlider.MarkerGroup>
-        <ArkSlider.Control className="ds-flex">
-          <ArkSlider.Track className="ds-flex ds-h-[5px] ds-grow ds-bg-bg-gray-2 ds-rounded-[4px]">
-            <ArkSlider.Range
-              className={cx('ds-h-[5px] ds-rounded-[8px]', {
-                'ds-bg-accent': !disabled,
-                'ds-bg-inactive-gray': disabled,
-              })}
+        <ArkSlider.Label className="ds-ml-6 ds-mr-5 ds-flex ds-items-center ds-text-body-xs">{label}</ArkSlider.Label>
+        <div className="ds-content-center ds-w-full">
+          <ArkSlider.MarkerGroup
+            className={cx('ds-z-10 ds-w-full', {
+              'ds-text-[#71A9CB]': !disabled,
+              'ds-text-inactive-gray': disabled,
+            })}
+          >
+            <ArkSlider.Marker value={0}>
+              <Marker />
+            </ArkSlider.Marker>
+            <ArkSlider.Marker value={25}>
+              <Marker />
+            </ArkSlider.Marker>
+            <ArkSlider.Marker value={50}>
+              <Marker />
+            </ArkSlider.Marker>
+            <ArkSlider.Marker value={75}>
+              <Marker />
+            </ArkSlider.Marker>
+            <ArkSlider.Marker value={100}>
+              <Marker />
+            </ArkSlider.Marker>
+          </ArkSlider.MarkerGroup>
+          <ArkSlider.Control className="ds-flex ds-grow ds-w-full">
+            <ArkSlider.Track className="ds-flex ds-h-[5px] ds-grow ds-bg-bg-gray-2 ds-rounded-sm">
+              <ArkSlider.Range
+                className={cx('ds-h-[5px] ds-rounded-md', {
+                  'ds-bg-accent': !disabled,
+                  'ds-bg-inactive-gray': disabled,
+                })}
+              />
+            </ArkSlider.Track>
+            <ArkSlider.Thumb
+              ref={refs.setReference}
+              {...getReferenceProps()}
+              aria-label={rightLabel ? `${label} - ${rightLabel}` : label}
+              index={0}
+              className={cx(
+                'ds-absolute -ds-top-[6px] ds-flex ds-size-[17px] ds-justify-center ds-rounded-full ds-z-20',
+                {
+                  'ds-bg-accent': !disabled,
+                  'ds-bg-inactive-gray': disabled,
+                },
+              )}
             />
-          </ArkSlider.Track>
-          <ArkSlider.Thumb
-            ref={refs.setReference}
-            {...getReferenceProps()}
-            aria-label={rightLabel ? `${label} - ${rightLabel}` : label}
-            index={0}
-            className={cx(
-              'ds-absolute -ds-top-[6px] ds-flex ds-size-[17px] ds-justify-center ds-rounded-full ds-z-20',
-              {
-                'ds-bg-accent': !disabled,
-                'ds-bg-inactive-gray': disabled,
-              },
-            )}
-          />
-        </ArkSlider.Control>
+          </ArkSlider.Control>
+        </div>
+        {rightLabel && (
+          <ArkSlider.Label className="ds-ml-5 ds-mr-6 ds-flex ds-items-center ds-text-body-xs">
+            {rightLabel}
+          </ArkSlider.Label>
+        )}
       </ArkSlider.Root>
-      {rightLabel && <span className="ds-ml-5 ds-mr-6 ds-flex ds-items-center ds-text-[12px]">{rightLabel}</span>}
       {focused && (
         <div
           ref={refs.setFloating}
-          className="ds-max-w-[292px] ds-rounded-[8px] ds-bg-black ds-px-6 ds-py-3 ds-text-button-md ds-text-white sm:ds-text-body-md ds-font-arial"
+          className="ds-max-w-[292px] ds-rounded-md ds-bg-black ds-px-6 ds-py-3 ds-text-button-md ds-text-white sm:ds-text-body-md ds-font-arial"
           style={floatingStyles}
           {...getFloatingProps()}
         >

--- a/lib/components/Textarea/Textarea.stories.tsx
+++ b/lib/components/Textarea/Textarea.stories.tsx
@@ -1,7 +1,6 @@
+import { useState } from '@storybook/preview-api';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
-import React from 'react';
-
 import { Textarea } from './Textarea';
 
 const meta = {
@@ -17,7 +16,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: (args: Story['args']) => {
     const { value, onChange, ...rest } = args;
-    const [textareaValue, setTextareaValue] = React.useState(value);
+    const [textareaValue, setTextareaValue] = useState(value);
     return (
       <Textarea
         value={textareaValue}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

* Fixed contrast related accessability issues reported by AXE by putting labels inside `ArkSlider.Label` and moving those inside `ArkSlider.Root`
* Used typography values instead of pixel values for border roundings and font-sizes
* Removed the use of `ds-bg-todo` classes as it's not present in DS
* Removed stories from eslint ignore, as it caused `lint-staged` to fail
* Ignored some sonarjs ESLint rules
* ~~Disabled `sonarjs/rules-of-hooks` ESLint rule for slider stories~~

I also compared the slider against the previous version (https://opetushallitus.github.io/jod-design-system/?path=/docs/components-slider--documentation)  and it seemed to still match.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1048
