### PR TITLE
OPHJOD-1066: Changed tooltip logic

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
   "*": ["prettier --check"],
-  "*.{ts,tsx}": ["eslint --report-unused-disable-directives --max-warnings 0"]
+  "*.{ts,tsx}": ["eslint --report-unused-disable-directives --max-warnings 0 --no-warn-ignored"]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,8 @@ import sonarjs from 'eslint-plugin-sonarjs';
 import storybook from 'eslint-plugin-storybook';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
-const __dirname = new URL('.', import.meta.url).pathname;
+import { fileURLToPath } from 'url';
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export default [
   {

--- a/lib/components/SelectionCard/SelectionCard.stories.tsx
+++ b/lib/components/SelectionCard/SelectionCard.stories.tsx
@@ -1,7 +1,9 @@
 import { useState } from '@storybook/preview-api';
 import type { Meta, StoryObj } from '@storybook/react';
+import { MdInfoOutline } from 'react-icons/md';
+import { JSX } from 'react/jsx-runtime';
 import { useMediaQueries } from '../../main';
-import { SelectionCard } from './SelectionCard';
+import { SelectionCard, SelectionCardProps } from './SelectionCard';
 
 const meta = {
   title: 'Cards/SelectionCard',
@@ -20,21 +22,24 @@ const parameters = {
   },
 };
 
-export const Default: Story = {
-  render: (args) => {
-    const [selected, setSelected] = useState(false);
-    const onClick = () => {
-      setSelected(!selected);
-    };
+const RenderDefault = (args: JSX.IntrinsicAttributes & SelectionCardProps) => {
+  const [selected, setSelected] = useState(false);
+  const onClick = () => {
+    setSelected(!selected);
+  };
 
-    return <SelectionCard {...args} selected={selected} onClick={onClick} />;
-  },
+  return <SelectionCard {...args} selected={selected} onClick={onClick} />;
+};
+
+export const Default: Story = {
+  render: RenderDefault,
   parameters,
   args: {
     label: 'Kartoittaa omaa osaamistani',
     icon: <span className="ds-text-[70px]">😎</span>,
     selected: false,
     infoAriaLabel: 'Info',
+    infoIcon: <MdInfoOutline size={24} />,
     tooltipContent: (
       <>
         <div className="ds-text-heading-4 ds-mb-4">Tavoitteen vaikutus tuloksiin</div>
@@ -46,66 +51,69 @@ export const Default: Story = {
     ),
   },
 };
+
+const RenderMultiple = () => {
+  const { sm } = useMediaQueries();
+  const [cardData, setCardData] = useState([
+    { icon: '🙈', selected: false, label: 'Lorem ipsum' },
+    { icon: '🙉', selected: false, label: 'Dolor sit amet' },
+    { icon: '🙊', selected: false, label: 'Consectetur adipiscing elit' },
+  ]);
+
+  const [info, setInfo] = useState('');
+
+  const onClick = (index: number) => () => {
+    setCardData((prev) => {
+      const data = [...prev];
+      data[index].selected = !data[index].selected;
+      return data;
+    });
+  };
+
+  const setInfoVisible = (index: number) => (visible: boolean) => {
+    // eslint-disable-next-line sonarjs/no-selector-parameter
+    if (visible && info !== cardData[index].label) {
+      setInfo(cardData[index].label);
+    } else if (!visible) {
+      setInfo('');
+    }
+  };
+
+  const CardList = () =>
+    cardData.map((card, index) => (
+      <SelectionCard
+        key={card.label}
+        label={card.label}
+        selected={card.selected}
+        onClick={onClick(index)}
+        setHovered={setInfoVisible(index)}
+        icon={<span className="ds-text-[70px]">{card.icon}</span>}
+        infoAriaLabel={`Info for ${card.label}`}
+        tooltipContent={
+          <div>
+            Tooltip for <strong>{card.label}</strong>
+          </div>
+        }
+      />
+    ));
+  return (
+    <>
+      {sm && <div>Showing info for card: {info}</div>}
+      {sm ? (
+        <div className="ds-flex ds-flex-row ds-gap-x-5">
+          <CardList />
+        </div>
+      ) : (
+        <div className="ds-flex ds-flex-col ds-gap-y-5">
+          <CardList />
+        </div>
+      )}
+    </>
+  );
+};
+
 export const MultipleWithHover: Story = {
-  render: () => {
-    const { sm } = useMediaQueries();
-    const [cardData, setCardData] = useState([
-      { icon: '🙈', selected: false, label: 'Lorem ipsum' },
-      { icon: '🙉', selected: false, label: 'Dolor sit amet' },
-      { icon: '🙊', selected: false, label: 'Consectetur adipiscing elit' },
-    ]);
-
-    const [info, setInfo] = useState('');
-
-    const onClick = (index: number) => () => {
-      setCardData((prev) => {
-        const data = [...prev];
-        data[index].selected = !data[index].selected;
-        return data;
-      });
-    };
-
-    const setInfoVisible = (index: number) => (visible: boolean) => {
-      // eslint-disable-next-line sonarjs/no-selector-parameter
-      if (visible && info !== cardData[index].label) {
-        setInfo(cardData[index].label);
-      } else if (!visible) {
-        setInfo('');
-      }
-    };
-
-    const CardList = () =>
-      cardData.map((card, index) => (
-        <SelectionCard
-          key={card.label}
-          label={card.label}
-          selected={card.selected}
-          onClick={onClick(index)}
-          setHovered={setInfoVisible(index)}
-          icon={<span className="ds-text-[70px]">{card.icon}</span>}
-          infoAriaLabel={`Info for ${card.label}`}
-          tooltipContent={
-            <div>
-              Tooltip for <strong>{card.label}</strong>
-            </div>
-          }
-        />
-      ));
-    return (
-      <>
-        {sm && <div>Showing info for card: {info}</div>}
-        {sm ? (
-          <div className="ds-flex ds-flex-row ds-gap-x-5">
-            <CardList />
-          </div>
-        ) : (
-          <div className="ds-flex ds-flex-col ds-gap-y-5">
-            <CardList />
-          </div>
-        )}
-      </>
-    );
-  },
+  render: RenderMultiple,
   parameters: {
     ...parameters,
   },

--- a/lib/components/SelectionCard/SelectionCard.tsx
+++ b/lib/components/SelectionCard/SelectionCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MdInfoOutline } from 'react-icons/md';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { TooltipContent } from '../Tooltip/TooltipContent';
 import { TooltipTrigger } from '../Tooltip/TooltipTrigger';
@@ -21,6 +20,7 @@ export interface SelectionCardProps {
   infoAriaLabel: string;
   /** Desktop or mobile variant */
   sm?: boolean;
+  infoIcon?: React.ReactNode;
 }
 
 const CheckIcon = () => (
@@ -42,6 +42,7 @@ export const SelectionCard = ({
   setHovered: setInfoVisible,
   tooltipContent,
   infoAriaLabel,
+  infoIcon,
   sm = true,
 }: SelectionCardProps) => {
   const [tooltipOpen, setTooltipOpen] = React.useState(false);
@@ -57,7 +58,65 @@ export const SelectionCard = ({
     setInfoVisible?.(false);
   };
 
-  return sm ? (
+  const showToolTip = () => {
+    setTooltipOpen(true);
+  };
+
+  const hideToolTip = () => {
+    setTooltipOpen(false);
+  };
+
+  const desktopCard = (
+    <button
+      type="button"
+      className="ds-flex ds-items-center ds-relative ds-w-full ds-p-3 ds-pr-0"
+      onClick={onClick}
+      aria-pressed={selected}
+      aria-label={label}
+    >
+      <span className="ds-absolute ds-left-0 ds-top-0 -ds-m-3" aria-hidden>
+        {selected ? <CheckIcon /> : null}
+      </span>
+      <span
+        className="ds-h-[93px] ds-aspect-square ds-rounded-full ds-bg-white ds-flex ds-items-center ds-justify-center"
+        aria-hidden
+      >
+        <span className="ds-transform ds-scale-75">{icon ?? null}</span>
+      </span>
+      <span className="ds-ml-5 ds-container ds-text-left ds-pr-4">
+        <span className="ds-text-heading-4-mobile">{label ?? ''}</span>
+      </span>
+    </button>
+  );
+
+  const desktopTooltipCard = (
+    <TooltipTrigger
+      type="button"
+      className="ds-flex ds-items-center ds-relative ds-w-full ds-p-3 ds-pr-0"
+      onClick={onClick}
+      aria-pressed={selected}
+      aria-label={label}
+      onMouseEnter={showToolTip}
+      onMouseLeave={hideToolTip}
+      onFocus={showToolTip}
+      onBlur={hideToolTip}
+    >
+      <span className="ds-absolute ds-left-0 ds-top-0 -ds-m-3" aria-hidden>
+        {selected ? <CheckIcon /> : null}
+      </span>
+      <span
+        className="ds-h-[93px] ds-aspect-square ds-rounded-full ds-bg-white ds-flex ds-items-center ds-justify-center"
+        aria-hidden
+      >
+        <span className="ds-transform ds-scale-75">{icon ?? null}</span>
+      </span>
+      <span className="ds-ml-5 ds-container ds-text-left ds-pr-4">
+        <span className="ds-text-heading-4-mobile">{label ?? ''}</span>
+      </span>
+    </TooltipTrigger>
+  );
+
+  const mobileCard = (
     <button
       type="button"
       className="ds-w-[166px] ds-min-h-[250px] ds-rounded-md ds-p-5 hover:ds-bg-secondary-1-25 ds-flex ds-flex-col ds-items-center"
@@ -80,45 +139,42 @@ export const SelectionCard = ({
         <span className="ds-text-heading-4">{label ?? ''}</span>
       </span>
     </button>
+  );
+
+  return sm ? (
+    mobileCard
   ) : (
     <div className="ds-min-h-[93px] ds-min-w-[280px] ds-rounded-md ds-bg-bg-gray-2 hover:ds-bg-secondary-1-25 ds-flex ds-flex-row">
-      <button
-        type="button"
-        className="ds-flex ds-items-center ds-relative ds-w-full ds-p-3 ds-pr-0"
-        onClick={onClick}
-        aria-pressed={selected}
-        aria-label={label}
-      >
-        <span className="ds-absolute ds-left-0 ds-top-0 -ds-m-3" aria-hidden>
-          {selected ? <CheckIcon /> : null}
-        </span>
-        <span
-          className="ds-h-[93px] ds-aspect-square ds-rounded-full ds-bg-white ds-flex ds-items-center ds-justify-center"
-          aria-hidden
-        >
-          <span className="ds-transform ds-scale-75">{icon ?? null}</span>
-        </span>
-        <span className="ds-ml-5 ds-text-start ds-pr-4">
-          <span className="ds-text-heading-4-mobile">{label ?? ''}</span>
-        </span>
-      </button>
-      {tooltipContent && React.isValidElement(tooltipContent) && (
-        <Tooltip open={tooltipOpen} placement="bottom-start">
-          <TooltipTrigger
-            className="ds-ml-auto ds-p-5"
-            aria-label={infoAriaLabel ?? ''}
-            onClick={(e) => {
-              e?.preventDefault?.();
-              e?.stopPropagation?.();
-              toggleTooltip();
-            }}
-          >
-            <MdInfoOutline size={24} />
-          </TooltipTrigger>
-          <TooltipContent className="ds-bg-black ds-text-white ds-rounded-xl ds-p-5 ds-z-50 ds-text-body-sm sm:ds-text-body-md ds-font-arial">
+      {!tooltipContent && !infoIcon && desktopCard}
+      {tooltipContent && !infoIcon && React.isValidElement(tooltipContent) && (
+        <Tooltip open={tooltipOpen} placement="bottom-end">
+          {desktopTooltipCard}
+
+          <TooltipContent className="ds-bg-black ds-text-white ds-rounded-xl ds-p-5 ds-z-50 ds-text-body-sm sm:ds-text-body-md ds-font-arial ds-max-w-[340px]">
             {tooltipContent}
           </TooltipContent>
         </Tooltip>
+      )}
+      {tooltipContent && infoIcon && React.isValidElement(tooltipContent) && (
+        <>
+          {desktopCard}
+          <Tooltip open={tooltipOpen} placement="bottom-end">
+            <TooltipTrigger
+              className="ds-ml-auto ds-p-5"
+              aria-label={infoAriaLabel ?? ''}
+              onClick={(e) => {
+                e?.preventDefault?.();
+                e?.stopPropagation?.();
+                toggleTooltip();
+              }}
+            >
+              {infoIcon}
+            </TooltipTrigger>
+            <TooltipContent className="ds-bg-black ds-text-white ds-rounded-xl ds-p-5 ds-z-50 ds-text-body-sm sm:ds-text-body-md ds-font-arial">
+              {tooltipContent}
+            </TooltipContent>
+          </Tooltip>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

This changes logic of the tooltip trigger.
Added optional infoIcon property, which allows user to customize look of the info button.
If component has infoIcon toolTip functionality is behind the info button. 

When infoIcon is missing toolTip is shown when selection card is hovered or focused and hidden on blur and mouse exit.

Other changes in this PR are related to eslint update, which caused errors in storybook rendering.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1066
