### PR TITLE
OPHJOD-1089: Add more info for screenreader in WizardProgress

### DIFF
--- a/lib/components/Modal/Modal.stories.tsx
+++ b/lib/components/Modal/Modal.stories.tsx
@@ -14,6 +14,16 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const ProgressComponent = () => (
+  <WizardProgress
+    labelText="Eteneminen"
+    stepText="Vaihe"
+    completedText="Valmis"
+    currentText="Nykyinen"
+    steps={4}
+    currentStep={2}
+  />
+);
 const LoremIpsum = ({ heading, length = 10 }: { heading: string; length?: number }) => {
   const loremIpsumText =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eget augue aliquam, varius ex nec, aliquet orci. Donec nec congue eros. Phasellus vulputate facilisis efficitur. Praesent non mi tellus. Donec lacinia congue condimentum. Ut suscipit, felis ac bibendum convallis, lectus nulla aliquet tortor, at egestas dolor ex non nunc. Aliquam id dolor ex. Sed eros arcu, scelerisque ut lorem nec, ornare rutrum magna. Nunc id leo condimentum massa convallis rhoncus id quis tortor. Mauris scelerisque ultrices mi, sit amet lobortis lorem placerat vitae. Etiam tincidunt interdum ante eu pretium. Integer suscipit velit et tortor gravida varius.';
@@ -113,7 +123,7 @@ export const DynamicContent: Story = {
         <Modal
           {...rest}
           sidePanel={hasSidePanel ? <LoremIpsum heading="Side panel" length={loremIpsumLength} /> : null}
-          progress={hasProgress ? <WizardProgress steps={4} currentStep={2} /> : null}
+          progress={hasProgress ? <ProgressComponent /> : null}
           content={
             <>
               <div className="ds-flex ds-flex-row ds-gap-4">
@@ -198,7 +208,7 @@ export const Progress: Story = {
     content: <LoremIpsum heading="Content" />,
     sidePanel: <LoremIpsum heading="Side panel" />,
     footer: <>/</>,
-    progress: <WizardProgress steps={4} currentStep={2} />,
+    progress: <ProgressComponent />,
   },
 };
 
@@ -249,6 +259,6 @@ export const MobileWithProgress: Story = {
     content: <LoremIpsum heading="Content" />,
     sidePanel: <LoremIpsum heading="Side panel" />,
     footer: <>/</>,
-    progress: <WizardProgress steps={4} currentStep={2} />,
+    progress: <ProgressComponent />,
   },
 };

--- a/lib/components/WizardProgress/WizardProgress.stories.tsx
+++ b/lib/components/WizardProgress/WizardProgress.stories.tsx
@@ -13,6 +13,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div lang="fi">
+        <button className="ds-sr-only">Interaktiivinen elementti</button>
+        <Story />
+      </div>
+    ),
+  ],
   parameters: {
     design: {
       type: 'figma',
@@ -27,5 +35,9 @@ export const Default: Story = {
   args: {
     steps: 5,
     currentStep: 2,
+    stepText: 'Vaihe',
+    completedText: 'Valmis',
+    currentText: 'Nykyinen',
+    labelText: 'Eteneminen',
   },
 };

--- a/lib/components/WizardProgress/WizardProgress.test.tsx
+++ b/lib/components/WizardProgress/WizardProgress.test.tsx
@@ -11,6 +11,8 @@ describe('WizardProgress', () => {
   it('renders correctly', () => {
     const { container } = render(
       <WizardProgress
+        labelText="Progress"
+        stepText="Step"
         steps={steps}
         currentStep={currentStep}
         completedText={completedText}

--- a/lib/components/WizardProgress/WizardProgress.tsx
+++ b/lib/components/WizardProgress/WizardProgress.tsx
@@ -5,34 +5,76 @@ export interface WizardProgressProps {
   steps: number;
   /** The current step in the wizard. */
   currentStep: number;
-  /** The text to display when a step is completed. */
-  completedText?: string;
-  /** The text to display when a step is the current step. */
-  currentText?: string;
+  /** The text for screenreader when a step is completed. */
+  completedText: string;
+  /** The text for screenreader when a step is the current step. */
+  currentText: string;
+  /** The text for describing meaning for screenreader for every step */
+  stepText: string;
+  /** The text for telling screenreader what the component is all about */
+  labelText: string;
 }
 
-/** A component that displays the progress of a wizard. */
-export const WizardProgress = ({ steps, currentStep, completedText, currentText }: WizardProgressProps) => {
+const Step = ({ step, stepText }: { step: number; stepText: string }) => {
   return (
-    <ol className="ds-flex ds-gap-4 ds-text-black sm:ds-text-heading-2 sm:ds-leading-[24px] ds-text-heading-3-mobile ds-leading-[16px]">
+    <>
+      <span className="ds-sr-only">{`${stepText}: `}</span>
+      <span className="ds-select-none">{step}</span>
+    </>
+  );
+};
+
+const CompletedStep = ({ text, step, stepText }: { text: string; step: number; stepText: string }) => {
+  return (
+    <>
+      <span className="ds-sr-only">{`${stepText}: ${step}, ${text}.`}</span>
+      <MdCheck role="presentation" size={24} />
+    </>
+  );
+};
+
+const CurrentStep = ({ text, step, stepText }: { text: string; step: number; stepText: string }) => {
+  return (
+    <>
+      <Step step={step} stepText={stepText} />
+      <span className="ds-sr-only">{`, ${text}.`}</span>
+    </>
+  );
+};
+
+/** A component that displays the progress of a wizard. */
+export const WizardProgress = ({
+  steps,
+  currentStep,
+  completedText,
+  currentText,
+  stepText,
+  labelText,
+}: WizardProgressProps) => {
+  const renderStep = (step: number) => {
+    if (step < currentStep) {
+      return <CompletedStep text={completedText} step={step} stepText={stepText} />;
+    } else if (step === currentStep) {
+      return <CurrentStep text={currentText} step={step} stepText={stepText} />;
+    } else {
+      return <Step step={step} stepText={stepText} />;
+    }
+  };
+
+  return (
+    <ol
+      className="ds-flex ds-gap-4 ds-text-black sm:ds-text-heading-2 sm:ds-leading-[24px] ds-text-heading-3-mobile ds-leading-[16px]"
+      aria-label={labelText}
+    >
       {Array.from({ length: steps }, (_, index) => (
         <li
           key={index + 1}
           className={`ds-flex ds-min-h-7 ds-min-w-7 ds-items-center ds-justify-center ds-rounded-full ${
             index + 1 === currentStep ? 'ds-bg-accent ds-text-white' : 'ds-bg-bg-gray-2'
           } sm:ds-min-h-8 sm:ds-min-w-8`}
+          aria-current={index + 1 === currentStep}
         >
-          {index + 1 < currentStep ? (
-            <>
-              {completedText && <span className="ds-sr-only">{`${completedText}: ${index + 1}`}</span>}
-              <MdCheck size={24} />
-            </>
-          ) : (
-            <>
-              {index + 1 === currentStep && currentText && <span className="ds-sr-only">{`${currentText}: `}</span>}
-              <span className="ds-select-none">{index + 1}</span>
-            </>
-          )}
+          {renderStep(index + 1)}
         </li>
       ))}
     </ol>

--- a/lib/components/WizardProgress/__snapshots__/WizardProgress.test.tsx.snap
+++ b/lib/components/WizardProgress/__snapshots__/WizardProgress.test.tsx.snap
@@ -2,19 +2,22 @@
 
 exports[`WizardProgress > renders correctly 1`] = `
 <ol
+  aria-label="Progress"
   class="ds-flex ds-gap-4 ds-text-black sm:ds-text-heading-2 sm:ds-leading-[24px] ds-text-heading-3-mobile ds-leading-[16px]"
 >
   <li
+    aria-current="false"
     class="ds-flex ds-min-h-7 ds-min-w-7 ds-items-center ds-justify-center ds-rounded-full ds-bg-bg-gray-2 sm:ds-min-h-8 sm:ds-min-w-8"
   >
     <span
       class="ds-sr-only"
     >
-      Completed: 1
+      Step: 1, Completed.
     </span>
     <svg
       fill="currentColor"
       height="24"
+      role="presentation"
       stroke="currentColor"
       stroke-width="0"
       viewBox="0 0 24 24"
@@ -31,16 +34,18 @@ exports[`WizardProgress > renders correctly 1`] = `
     </svg>
   </li>
   <li
+    aria-current="false"
     class="ds-flex ds-min-h-7 ds-min-w-7 ds-items-center ds-justify-center ds-rounded-full ds-bg-bg-gray-2 sm:ds-min-h-8 sm:ds-min-w-8"
   >
     <span
       class="ds-sr-only"
     >
-      Completed: 2
+      Step: 2, Completed.
     </span>
     <svg
       fill="currentColor"
       height="24"
+      role="presentation"
       stroke="currentColor"
       stroke-width="0"
       viewBox="0 0 24 24"
@@ -57,22 +62,34 @@ exports[`WizardProgress > renders correctly 1`] = `
     </svg>
   </li>
   <li
+    aria-current="true"
     class="ds-flex ds-min-h-7 ds-min-w-7 ds-items-center ds-justify-center ds-rounded-full ds-bg-accent ds-text-white sm:ds-min-h-8 sm:ds-min-w-8"
   >
     <span
       class="ds-sr-only"
     >
-      Current: 
+      Step: 
     </span>
     <span
       class="ds-select-none"
     >
       3
     </span>
+    <span
+      class="ds-sr-only"
+    >
+      , Current.
+    </span>
   </li>
   <li
+    aria-current="false"
     class="ds-flex ds-min-h-7 ds-min-w-7 ds-items-center ds-justify-center ds-rounded-full ds-bg-bg-gray-2 sm:ds-min-h-8 sm:ds-min-w-8"
   >
+    <span
+      class="ds-sr-only"
+    >
+      Step: 
+    </span>
     <span
       class="ds-select-none"
     >
@@ -80,8 +97,14 @@ exports[`WizardProgress > renders correctly 1`] = `
     </span>
   </li>
   <li
+    aria-current="false"
     class="ds-flex ds-min-h-7 ds-min-w-7 ds-items-center ds-justify-center ds-rounded-full ds-bg-bg-gray-2 sm:ds-min-h-8 sm:ds-min-w-8"
   >
+    <span
+      class="ds-sr-only"
+    >
+      Step: 
+    </span>
     <span
       class="ds-select-none"
     >


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Add more information for screenreader user
  - `labelText` telling where user landed
  - `stepText` tells what the number is 
- Made the existing `completedText` and `currentText` required as screenreader users should always have the same information.

-  Added a decorator for the story to be read in Finnish and to add one interactive element to a story, so it easier to get screenreader (at least VoiceOver to catch on to component)

**Includes breaking changes, so there is need for UI-side changes when updating to use updated version of DS on there.**

## Additional info

- As you can see from the screenshots, VoiceOver draws the text where the text would be if it is visible. It does not seem to honor the size of the element that Tailwind gives with the style.
- I tried to use `aria-label` but with that, VoiceOver tells every step as a empty group. It was confusing.
- The solution is not ideal. Maybe later we can think of adding "titles" for each step, so using the same text as title as the Modal uses for heading.

## Screenshots
Note that the screenreader in screenshots "speaks" English for the system parts as I have set it in English. `list`, `items`, `1 of 5` etc.

<img width="400" alt="wiz-0" src="https://github.com/user-attachments/assets/45b0754e-1cb6-49c8-bd00-bad5f13db21d">
<img width="400" alt="wiz-1" src="https://github.com/user-attachments/assets/fc957463-9c8b-4b68-b260-2531c22e7bcd">
<img width="400" alt="wiz-2" src="https://github.com/user-attachments/assets/60f863f2-0391-47c4-96bc-a446d26caa1c">
<img width="400" alt="wiz-3" src="https://github.com/user-attachments/assets/42b8e62e-b014-4e2d-ac5e-a4385f49b3a8">




## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1089
