### PR TITLE
OPHJOD-1090: Add translations prop for DatePicker

### DIFF
--- a/lib/components/Datepicker/Datepicker.stories.tsx
+++ b/lib/components/Datepicker/Datepicker.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 
 import { useState } from '@storybook/preview-api';
+import { DateView, DayTableCellState } from '@zag-js/date-picker';
 import { Datepicker } from './Datepicker';
 
 const meta = {
@@ -21,11 +22,38 @@ const parameters = {
   },
 };
 
+const viewTranslations = {
+  day: {
+    next: 'Vaihda seuraavaan kuukauteen',
+    view: 'Vaihda kuukausinäkymään',
+    prev: 'Vaihda edelliseen kuukauteen',
+  },
+  month: {
+    next: 'Vaihda seuraavaan vuoteen',
+    view: 'Vaihda vuosinäkymään',
+    prev: 'Vaihda edelliseen vuoteen',
+  },
+  year: {
+    next: 'Vaihda seuraavaan vuosikymmeneen',
+    view: 'Vaihda päivänäkymään',
+    prev: 'Vaihda edelliseen vuosikymmeneen',
+  },
+} as const;
+
+const translations = {
+  nextTrigger: (view: DateView) => viewTranslations[view].next,
+  viewTrigger: (view: DateView) => viewTranslations[view].view,
+  prevTrigger: (view: DateView) => viewTranslations[view].prev,
+  dayCell: (state: DayTableCellState): string => `Valitse ${state.formattedDate}`,
+  trigger: (open: boolean): string => (open ? 'Sulje kalenteri' : 'Avaa kalenteri'),
+};
+
 const args = {
   label: 'Valitse päivämäärä',
   placeholder: 'pp.kk.vvvv',
   help: 'Help text',
   onChange: fn(),
+  translations: translations,
 };
 
 export const Default: Story = {

--- a/lib/components/Datepicker/Datepicker.test.tsx
+++ b/lib/components/Datepicker/Datepicker.test.tsx
@@ -1,5 +1,6 @@
 import { userEvent } from '@storybook/test';
 import { act, render, screen } from '@testing-library/react';
+import { DateView, DayTableCellState } from '@zag-js/date-picker';
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Datepicker } from './Datepicker';
@@ -14,29 +15,84 @@ describe('Datepicker', () => {
   afterEach(() => {
     onChange.mockClear();
   });
+  const viewTranslations = {
+    day: {
+      next: 'Switch to next month',
+      view: 'Switch to month view',
+      prev: 'Switch to previous month',
+    },
+    month: {
+      next: 'Switch to next year',
+      view: 'Switch to year view',
+      prev: 'Switch to previous year',
+    },
+    year: {
+      next: 'Switch to next decade',
+      view: 'Switch to day view',
+      prev: 'Switch to previous decade',
+    },
+  } as const;
+
+  const translations = {
+    nextTrigger: (view: DateView) => viewTranslations[view].next,
+    viewTrigger: (view: DateView) => viewTranslations[view].view,
+    prevTrigger: (view: DateView) => viewTranslations[view].prev,
+    dayCell: (state: DayTableCellState): string => `Choose ${state.formattedDate}`,
+    trigger: (open: boolean): string => (open ? 'Close calendar' : 'Open calendar'),
+  };
 
   it('renders correctly', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2024, 6, 1, 12, 0, 0));
     const { container } = render(
-      <Datepicker label={label} placeholder={placeholder} value={value} onChange={onChange} />,
+      <Datepicker
+        label={label}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        translations={translations}
+      />,
     );
     expect(container.firstChild).toMatchSnapshot();
     vi.useRealTimers();
   });
 
   it('renders the correct label', () => {
-    render(<Datepicker label={label} placeholder={placeholder} value={value} onChange={onChange} />);
+    render(
+      <Datepicker
+        label={label}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        translations={translations}
+      />,
+    );
     expect(screen.getByText(label)).toBeInTheDocument();
   });
 
   it('renders the correct initial value', () => {
-    render(<Datepicker label={label} placeholder={placeholder} value={value} onChange={onChange} />);
+    render(
+      <Datepicker
+        label={label}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        translations={translations}
+      />,
+    );
     expect(screen.getByDisplayValue(formattedValue)).toBeInTheDocument();
   });
 
   it('calls onValueChange when a new date is typed into the input', async () => {
-    render(<Datepicker name="startDate" label={label} placeholder={placeholder} onChange={onChange} />);
+    render(
+      <Datepicker
+        name="startDate"
+        label={label}
+        placeholder={placeholder}
+        onChange={onChange}
+        translations={translations}
+      />,
+    );
     const input = screen.getByRole('textbox');
     const user = userEvent.setup();
     await act(async () => {
@@ -64,6 +120,7 @@ describe('Datepicker', () => {
         placeholder={placeholder}
         onChange={onChangeMock}
         value={value.date}
+        translations={translations}
       />,
     );
     const input = screen.getByRole('textbox');

--- a/lib/components/Datepicker/Datepicker.tsx
+++ b/lib/components/Datepicker/Datepicker.tsx
@@ -1,4 +1,10 @@
-import { DatePicker as ArkDatePicker, parseDate, Portal, UseDatePickerContext } from '@ark-ui/react';
+import {
+  DatePicker as ArkDatePicker,
+  DatePickerRootProps,
+  parseDate,
+  Portal,
+  UseDatePickerContext,
+} from '@ark-ui/react';
 import React from 'react';
 import { MdArrowBack, MdArrowForward, MdCalendarMonth } from 'react-icons/md';
 import { cx } from '../../cva';
@@ -51,6 +57,11 @@ const Header = () => (
   </ArkDatePicker.ViewControl>
 );
 
+type ArkTranslationsInUse = Pick<
+  Required<DatePickerRootProps>['translations'],
+  'nextTrigger' | 'viewTrigger' | 'prevTrigger' | 'dayCell' | 'trigger'
+>;
+
 export interface DatepickerProps {
   /** Name of the input field */
   name?: string;
@@ -66,15 +77,31 @@ export interface DatepickerProps {
   placeholder?: string;
   /** Help text to display below the input field */
   help?: string;
-}
 
+  translations: ArkTranslationsInUse;
+}
 /** Datepicker component for selecting a date. */
 export const Datepicker = React.forwardRef<HTMLInputElement, DatepickerProps>(function Datepicker(
-  { value, name, label, placeholder, help, onBlur, onChange }: DatepickerProps,
+  { value, name, label, placeholder, help, onBlur, onChange, translations }: DatepickerProps,
   ref,
 ) {
   const helpId = React.useId();
   const timeZone = 'Europe/Helsinki';
+
+  const arkTranslations: DatePickerRootProps['translations'] = {
+    ...translations,
+    // Not in use, but required to be defined for Ark-UI
+    clearTrigger: '',
+    content: '',
+    monthSelect: '',
+    placeholder: function (_locale: string): { year: string; month: string; day: string } {
+      return { year: '', month: '', day: '' };
+    },
+    presetTrigger: function (_value: string[]): string {
+      return '';
+    },
+    yearSelect: '',
+  };
 
   return (
     <ArkDatePicker.Root
@@ -88,6 +115,7 @@ export const Datepicker = React.forwardRef<HTMLInputElement, DatepickerProps>(fu
       timeZone={timeZone}
       className="ds-w-full"
       isDateUnavailable={(date) => isInvalidYear(date.year)}
+      translations={arkTranslations}
     >
       <ArkDatePicker.Label className="ds-mb-4 ds-inline-block ds-align-top ds-text-form-label ds-font-arial ds-text-black">
         {label}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Add `translations` prop for `DatePicker` component.

Able to now have localized values for screenreader users.

## Notes
As Ark-UI is used under the hood, these seems pretty tedious to use. Maybe we can use somekind of wrapper and give the `translations` properties in different way.
Because there is like 6 values (`clearTrigger,  content,  monthSelect, placeholder, presetTrigger, yearSelect`) that must given, as they are required by the Ark-UI which are not in use/or brings significant information.

**EDIT**: I made a change and picked only the used properties from the Ark-UI type of translations so that there is no need to give the unused translations properties everytime.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1090
