### PR TITLE
OPHJOD-1353: Add support, tests, and examples for indeterminate-state checkboxes

### DIFF
--- a/lib/components/Checkbox/Checkbox.stories.tsx
+++ b/lib/components/Checkbox/Checkbox.stories.tsx
@@ -206,3 +206,152 @@ export const ComponentAsLabel: Story = {
   },
   render,
 };
+
+export const IndeterminateCheckbox: Story = {
+  parameters: {
+    design,
+    docs: {
+      description: {
+        story:
+          'This is a indeterminate checkbox that cycles between unchecked → indeterminate → checked → unchecked states.',
+      },
+    },
+  },
+  args: {
+    name: 'indeterminate-state-checkbox',
+    value: 'indeterminate-state',
+    checked: false,
+    label: 'Indeterminate checkbox',
+    ariaLabel: 'Indeterminate checkbox',
+  },
+  render: () => {
+    const [state, setState] = useState<'unchecked' | 'indeterminate' | 'checked'>('unchecked');
+
+    const cycleState = () => {
+      if (state === 'unchecked') {
+        setState('indeterminate');
+      } else if (state === 'indeterminate') {
+        setState('checked');
+      } else {
+        setState('unchecked');
+      }
+    };
+
+    return (
+      <div className="ds:flex ds:flex-col ds:gap-4">
+        <Checkbox
+          name="indeterminate-state-checkbox"
+          value="indeterminate-state"
+          checked={state === 'checked'}
+          indeterminate={state === 'indeterminate'}
+          onChange={cycleState}
+          label="Indeterminate-state checkbox"
+          ariaLabel="Indeterminate-state checkbox"
+        />
+        <Checkbox
+          name="indeterminate-state-checkbox"
+          value="indeterminate-state"
+          checked={state === 'checked'}
+          indeterminate={state === 'indeterminate'}
+          onChange={cycleState}
+          label="Indeterminate-state checkbox with Bordered"
+          ariaLabel="Indeterminate-state checkbox"
+          variant="bordered"
+        />
+      </div>
+    );
+  },
+};
+
+export const IndeterminateCheckboxWithChildren: Story = {
+  parameters: {
+    design,
+    docs: {
+      description: {
+        story:
+          'A practical example of the indeterminate state with a parent checkbox controlling multiple child checkboxes.',
+      },
+    },
+  },
+  args: {
+    name: 'parent',
+    value: 'parent',
+    checked: false,
+    label: 'Select all items',
+    ariaLabel: 'Select all items',
+  },
+  render: () => {
+    // Track states of children checkboxes
+    const [childrenState, setChildrenState] = useState([false, false, false]);
+
+    // Calculate parent state based on children
+    const allChecked = childrenState.every((state) => state);
+    const someChecked = childrenState.some((state) => state);
+    const parentChecked = allChecked;
+    const parentIndeterminate = someChecked && !allChecked;
+
+    const handleParentChange = () => {
+      const newState = !allChecked;
+      setChildrenState(childrenState.map(() => newState));
+    };
+
+    const handleChildChange = (index: number) => {
+      const newChildrenState = [...childrenState];
+      newChildrenState[index] = !newChildrenState[index];
+      setChildrenState(newChildrenState);
+    };
+
+    return (
+      <div className="ds:flex ds:flex-col ds:gap-3">
+        <Checkbox
+          name="parent"
+          value="parent"
+          checked={parentChecked}
+          indeterminate={parentIndeterminate}
+          onChange={handleParentChange}
+          label="Select all items"
+          ariaLabel="Select all items"
+        />
+        <div className="ds:ml-6 ds:flex ds:flex-col ds:gap-2">
+          {['Item 1', 'Item 2', 'Item 3'].map((item, index) => (
+            <Checkbox
+              key={item}
+              name={`child-${index}`}
+              value={`child-${index}`}
+              checked={childrenState[index]}
+              onChange={() => handleChildChange(index)}
+              label={item}
+              ariaLabel={item}
+            />
+          ))}
+        </div>
+
+        <div className="mt-10" />
+        <Checkbox
+          name="parent"
+          value="parent"
+          checked={parentChecked}
+          indeterminate={parentIndeterminate}
+          onChange={handleParentChange}
+          label="Select all items (with Bordered)"
+          ariaLabel="Select all items (with Bordered)"
+          variant="bordered"
+        />
+        <div className="ds:ml-6 ds:flex ds:flex-col ds:gap-2">
+          {['Item 1', 'Item 2', 'Item 3'].map((item, index) => (
+            <Checkbox
+              key={item}
+              name={`child-${index}`}
+              value={`child-${index}`}
+              checked={childrenState[index]}
+              onChange={() => handleChildChange(index)}
+              label={item}
+              ariaLabel={item}
+              variant="bordered"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  },
+};

--- a/lib/components/Checkbox/Checkbox.test.tsx
+++ b/lib/components/Checkbox/Checkbox.test.tsx
@@ -58,4 +58,30 @@ describe('Checkbox', () => {
     const checkbox = screen.getByLabelText(label);
     expect(checkbox).toBeChecked();
   });
+
+  it('applies accent color to checked icon when checked', () => {
+    const { container } = render(
+      <Checkbox name="myCheckbox" label={label} ariaLabel={label} onChange={vi.fn()} value={myValue} checked={true} />,
+    );
+    const checkedIcon = container.querySelector('svg[data-state="visible"]');
+    expect(checkedIcon).toHaveClass('ds:text-accent');
+    expect(checkedIcon).toBeVisible();
+  });
+
+  it('shows indeterminate icon with accent fill when in indeterminate state', () => {
+    const { container } = render(
+      <Checkbox
+        name="myCheckbox"
+        label={label}
+        ariaLabel={label}
+        onChange={vi.fn()}
+        value={myValue}
+        checked={false}
+        indeterminate={true}
+      />,
+    );
+    const indeterminateIcon = container.querySelector('svg:not([data-state])');
+    expect(indeterminateIcon).toHaveClass('ds:fill-accent');
+    expect(indeterminateIcon).toBeVisible();
+  });
 });

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -10,6 +10,8 @@ export interface CheckboxProps {
   value: string;
   /** Checked state for the component */
   checked: boolean;
+  /** Indeterminate state for the component (takes precedence over checked) */
+  indeterminate?: boolean;
   /** Change event for the component */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   /** Text or component used as label for the component */
@@ -25,12 +27,14 @@ export interface CheckboxProps {
 
 /**
  * Checkboxes allow users to select multiple items from a list of individual items, or to mark one individual item as selected.
+ * Supports three states (requires prop 'indeterminate: true'): checked, unchecked, and indeterminate.
  */
 export const Checkbox = ({
   name,
   disabled,
   value,
   checked,
+  indeterminate = false,
   onChange,
   label,
   ariaLabel,
@@ -38,7 +42,15 @@ export const Checkbox = ({
   variant = 'default',
 }: CheckboxProps) => {
   const id = React.useId();
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const isLabelValidElement = React.isValidElement(label);
+
+  React.useEffect(() => {
+    // Apply indeterminate property to input element (as it can't be set via HTML attributes)
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate]);
 
   const borderVariantClassnames = {
     'ds:border ds:border-accent': variant === 'bordered',
@@ -50,6 +62,7 @@ export const Checkbox = ({
   return (
     <div className={cx('ds:flex ds:items-center ds:text-left ds:relative', className)}>
       <input
+        ref={inputRef}
         type="checkbox"
         id={label ? id : undefined}
         name={name}
@@ -58,19 +71,38 @@ export const Checkbox = ({
         checked={checked}
         onChange={onChange}
         aria-label={label ? undefined : ariaLabel}
+        aria-checked={indeterminate ? 'mixed' : checked}
         className={cx('ds:peer ds:size-5 ds:min-h-5 ds:min-w-5 ds:appearance-none ds:rounded-none ds:bg-white', {
           ...borderVariantClassnames,
         })}
       />
+      {/* Checked icon */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="16"
         height="16"
         viewBox="0 0 16 16"
         fill="none"
-        className="ds:pointer-events-none ds:absolute ds:hidden ds:fill-accent ds:peer-checked:block"
+        className="ds:pointer-events-none ds:absolute ds:hidden ds:text-accent ds:peer-checked:block"
+        data-state={indeterminate ? 'hidden' : 'visible'}
+        style={{ display: checked && !indeterminate ? 'block' : 'none' }}
       >
-        <rect x="0" y="0" width="16" height="16" />
+        {variant === 'bordered' && (
+          <rect x="0" y="0" width="16" height="16" stroke="currentColor" strokeWidth="2" fill="none" />
+        )}
+        <path d="M4 8l3 3l5-5" stroke="currentColor" strokeWidth="2" fill="none" />
+      </svg>
+      {/* Indeterminate icon */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        className="ds:pointer-events-none ds:absolute ds:fill-accent"
+        style={{ display: indeterminate ? 'block' : 'none' }}
+      >
+        <rect x="3" y="7" width="10" height="2" />
       </svg>
       {label && (
         <label

--- a/lib/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/lib/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Checkbox > renders correctly 1`] = `
   class="ds:flex ds:items-center ds:text-left ds:relative"
 >
   <input
+    aria-checked="false"
     class="ds:peer ds:size-5 ds:min-h-5 ds:min-w-5 ds:appearance-none ds:rounded-none ds:bg-white ds:border-0"
     id=":r0:"
     name="myCheckbox"
@@ -12,18 +13,36 @@ exports[`Checkbox > renders correctly 1`] = `
     value="myValue"
   />
   <svg
-    class="ds:pointer-events-none ds:absolute ds:hidden ds:fill-accent ds:peer-checked:block"
+    class="ds:pointer-events-none ds:absolute ds:hidden ds:text-accent ds:peer-checked:block"
+    data-state="visible"
     fill="none"
     height="16"
+    style="display: none;"
+    viewBox="0 0 16 16"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M4 8l3 3l5-5"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+    />
+  </svg>
+  <svg
+    class="ds:pointer-events-none ds:absolute ds:fill-accent"
+    fill="none"
+    height="16"
+    style="display: none;"
     viewBox="0 0 16 16"
     width="16"
     xmlns="http://www.w3.org/2000/svg"
   >
     <rect
-      height="16"
-      width="16"
-      x="0"
-      y="0"
+      height="2"
+      width="10"
+      x="3"
+      y="7"
     />
   </svg>
   <label


### PR DESCRIPTION
## Description

This pull request adds a new feature to the Checkbox component to support indeterminate-state representation: checked, unchecked, and indeterminate. Updates include:

- Implementing logic to handle the indeterminate state with proper `aria-checked` accessibility attributes set to "mixed."
- Adding tests for all three states to ensure functionality and reliability.
- Providing Storybook examples, including a single three-state checkbox and a parent-child structure demonstrating indeterminate state behavior when controlling child checkboxes.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1353