### PR TITLE
OPHJOD-1339: Allow main modal content to take all available width with progress bar

### DIFF
--- a/lib/components/Modal/Modal.stories.tsx
+++ b/lib/components/Modal/Modal.stories.tsx
@@ -132,6 +132,28 @@ export const DefaultWithoutSidePanel: Story = {
   },
 };
 
+export const FullWidthContent: Story = {
+  render,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-7639&t=b8o6NAta57e3aj8E-1',
+    },
+    docs: {
+      description: {
+        story: 'This is a modal component with full width content. Should only be used without side panel.',
+      },
+    },
+  },
+  args: {
+    open: false,
+    onClose: fn(),
+    content: <LoremIpsum heading="Content" />,
+    footer: <>/</>,
+    fullWidthContent: true,
+  },
+};
+
 export const DynamicContent: Story = {
   render: (args: Story['args']) => {
     const { open, onClose, ...rest } = args;
@@ -155,14 +177,14 @@ export const DynamicContent: Story = {
                 <button
                   type="button"
                   onClick={() => setHasProgress(!hasProgress)}
-                  className="ds:cursor-pointer ds:shadow-border ds:bg-accent ds:text-white ds:p-5"
+                  className="ds:cursor-pointer ds:shadow-border ds:bg-accent ds:text-white ds:p-2"
                 >
                   Toggle progress
                 </button>
                 <button
                   type="button"
                   onClick={() => setHasSidePanel(!hasSidePanel)}
-                  className="ds:cursor-pointer ds:shadow-border ds:bg-accent ds:text-white ds:p-5"
+                  className="ds:cursor-pointer ds:shadow-border ds:bg-accent ds:text-white ds:p-2"
                 >
                   Toggle side panel
                 </button>

--- a/lib/components/Modal/Modal.tsx
+++ b/lib/components/Modal/Modal.tsx
@@ -11,10 +11,19 @@ export interface ModalProps {
   progress?: React.ReactNode;
   /** Slot is not used on mobile. */
   sidePanel?: React.ReactNode;
+  fullWidthContent?: boolean;
 }
 
 /** Modals are containers appearing in front of the main content to provide critical information or an actionable piece of content. */
-export const Modal = ({ open, onClose, content, progress, sidePanel, footer }: ModalProps) => {
+export const Modal = ({
+  open,
+  onClose,
+  content,
+  progress,
+  sidePanel,
+  footer,
+  fullWidthContent = false,
+}: ModalProps) => {
   const { sm } = useMediaQueries();
   const id = React.useId();
 
@@ -72,9 +81,11 @@ export const Modal = ({ open, onClose, content, progress, sidePanel, footer }: M
                 'ds:sm:grid-cols-3',
                 'ds:pl-5',
                 'ds:md:pl-9',
+                'ds:relative',
               ])}
             >
               {/* Main content */}
+              {progress && <div className="ds:absolute ds:top-0 ds:right-5">{progress}</div>}
               <div
                 className={tc([
                   heightClasses,
@@ -83,25 +94,26 @@ export const Modal = ({ open, onClose, content, progress, sidePanel, footer }: M
                   'ds:flex-col',
                   'ds:gap-y-6',
                   'ds:pr-5',
-                  (sidePanel ?? progress) ? 'ds:sm:col-span-2' : 'ds:sm:col-span-3 ds:mr-0 ds:sm:mr-5 ds:md:mr-9',
+                  sidePanel || !fullWidthContent
+                    ? 'ds:sm:col-span-2'
+                    : 'ds:sm:col-span-3 ds:mr-0 ds:sm:mr-5 ds:md:mr-9',
+                  progress && !sm ? 'ds:mt-6 ds:sm:mt-8' : '',
                   'ds:sm:pr-0',
                 ])}
               >
-                {progress && !sm && <div className="ds:flex ds:justify-end">{progress}</div>}
-                <div className="ds:overflow-y-auto ds:sm:mt-6 ds:p-3 ds:-m-3">{content}</div>
+                <div className={`ds:overflow-y-auto ds:p-3 ${progress ? 'ds:mt-8' : ''}`}>{content}</div>
               </div>
               {/* Side panel */}
-              {sm && (sidePanel ?? progress) && (
+              {sm && sidePanel && !fullWidthContent && (
                 <div className={`ds:col-span-1 ds:flex ds:flex-col ${heightClasses}`}>
-                  {progress && <div className="ds:mr-6 ds:flex ds:justify-end">{progress}</div>}
-                  <div className={`ds:mr-5 ds:sm:mr-9 ds:overflow-y-auto ${!progress ? 'ds:sm:mt-6' : ''}`}>
+                  <div className={`ds:mr-5 ds:sm:mr-9 ds:overflow-y-auto ${progress ? 'ds:sm:mt-8 ds:mt-6' : ''}`}>
                     {sidePanel}
                   </div>
                 </div>
               )}
             </div>
             {/* Footer, button area */}
-            <div className="ds:bg-bg-gray-2 ds:overflow-x-auto ds:overflow-y-hidden ds:justify-between ds:py-4 ds:sm:py-5 ds:px-4 ds:sm:px-9">
+            <div className="ds:bg-bg-gray-2 ds:overflow-x-auto ds:overflow-y-hidden ds:justify-between ds:py-4 ds:sm:py-5 ds:px-4 ds:sm:px-9 ds:z-50">
               {footer}
             </div>
           </DialogPanel>


### PR DESCRIPTION
## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

* Allow the main modal content to take up the full width while showing the progress component when sidebar is not defined

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1339

![image](https://github.com/user-attachments/assets/59c71b96-d88f-409b-8da1-1cb69d4f016c)

