### PR TITLE
OPHJOD-1439: Fix Accordion bottom margin when children are hidden

### DIFF
--- a/lib/components/Accordion/Accordion.tsx
+++ b/lib/components/Accordion/Accordion.tsx
@@ -17,7 +17,7 @@ type AccordionProps = {
   children: React.ReactNode;
   lang: string;
   underline?: boolean;
-  intialState?: boolean;
+  initialState?: boolean;
 } & TitleProps;
 
 const Caret = ({ isOpen }: { isOpen: boolean }) => (
@@ -26,21 +26,22 @@ const Caret = ({ isOpen }: { isOpen: boolean }) => (
   </span>
 );
 
-export const Accordion = ({ title, titleText, children, lang, underline, intialState = true }: AccordionProps) => {
-  const [isOpen, setIsOpen] = React.useState(intialState);
+export const Accordion = ({ title, titleText, children, lang, underline, initialState = true }: AccordionProps) => {
+  const [isOpen, setIsOpen] = React.useState(initialState);
   const toggleOpen = () => setIsOpen(!isOpen);
   const isTitleValidElement = React.isValidElement(title);
   const wrapperClassnames = cx(
-    'ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:mb-2 ds:group-hover:text-accent!',
+    'ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:group-hover:text-accent!',
     {
       'ds:border-b ds:border-border-gray': underline,
+      'ds:mb-2': isOpen,
     },
   );
 
   // Reset the state when the children change
   React.useEffect(() => {
-    setIsOpen(intialState);
-  }, [children, intialState]);
+    setIsOpen(initialState);
+  }, [children, initialState]);
 
   return (
     <>

--- a/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Accordion > renders accordion with open state by default 1`] = `
 >
   <button
     aria-expanded="true"
-    class="ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:mb-2 ds:group-hover:text-accent!"
+    class="ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:group-hover:text-accent! ds:mb-2"
   >
     <span
       class="ds:mr-5 ds:w-full ds:text-left ds:hyphens-auto ds:text-heading-3 ds:group-hover:underline"


### PR DESCRIPTION
## Description
- Fix Accordion bottom margin when children are hidden
- Fix initialState property name
## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1439
