### PR TITLE
OPHJOD-1440: Add static theme option to generate all CSS variables

### DIFF
--- a/lib/theme.css
+++ b/lib/theme.css
@@ -1,4 +1,4 @@
-@theme {
+@theme static {
   --breakpoint-*: initial;
   --breakpoint-sm: 640px;
   --breakpoint-md: 768px;


### PR DESCRIPTION

## Description
In Tailwind version 4.0.5, a change (https://github.com/tailwindlabs/tailwindcss/pull/16211) was introduced that causes only the used variables to be included in the final CSS. As a result, a component using the Design System cannot use any theme variable directly (e.g., var(--ds-color-secondary-3)) unless that variable has been used in one of the Design System's components. However, an option called static has been added to the theme rule, which, when used, includes all theme variables in the final CSS.


## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1440
