### PR TITLE
OPHJOD-1451: Change Tag component cursor for 'presentation' variant

### DIFF
--- a/lib/components/Tag/Tag.test.tsx
+++ b/lib/components/Tag/Tag.test.tsx
@@ -28,4 +28,22 @@ describe('Tag', () => {
     expect(queryByRole('button')).toBeNull();
     expect(container.querySelector('svg')).toBeNull();
   });
+
+  it('should have cursor-pointer class when variant is not presentation', () => {
+    const { container } = render(<Tag label="selectable" variant="selectable" onClick={vi.fn()} />);
+    const tagElement = container.firstChild;
+    expect(tagElement).toHaveClass('ds:cursor-pointer');
+  });
+
+  it('should not have cursor-pointer class when variant is presentation', () => {
+    const { container } = render(<Tag label="presentation" variant="presentation" />);
+    const tagElement = container.firstChild;
+    expect(tagElement).not.toHaveClass('ds:cursor-pointer');
+  });
+
+  it('should have cursor-pointer class by default (when variant not specified)', () => {
+    const { container } = render(<Tag label="default" onClick={vi.fn()} />);
+    const tagElement = container.firstChild;
+    expect(tagElement).toHaveClass('ds:cursor-pointer');
+  });
 });

--- a/lib/components/Tag/Tag.tsx
+++ b/lib/components/Tag/Tag.tsx
@@ -20,10 +20,11 @@ interface ActionableTagProps extends BaseTagProps {
 
 export type TagProps = PresentationTagProps | ActionableTagProps;
 
-const containerClassNames = (sourceType: TagProps['sourceType']) =>
+const containerClassNames = (sourceType: TagProps['sourceType'], variant: TagProps['variant']) =>
   cx(
-    'ds:cursor-pointer ds:group ds:inline-flex ds:select-none ds:items-center ds:rounded-xl ds:text-tag ds:font-arial ds:px-4 ds:py-2 ds:text-left',
+    'ds:group ds:inline-flex ds:select-none ds:items-center ds:rounded-xl ds:text-tag ds:font-arial ds:px-4 ds:py-2 ds:text-left',
     {
+      'ds:cursor-pointer': variant !== 'presentation',
       'ds:bg-tag-tyopaikka': sourceType === 'tyopaikka',
       'ds:bg-tag-koulutus': sourceType === 'koulutus',
       'ds:bg-tag-vapaa-ajan-toiminto': sourceType === 'vapaa-ajan-toiminto',
@@ -36,11 +37,11 @@ const containerClassNames = (sourceType: TagProps['sourceType']) =>
 /** Tags allow users to categorize content. They can represent keywords or people, and are grouped to describe an item or a search request. */
 export const Tag = ({ label, title, onClick, variant = 'selectable', sourceType = 'jotain-muuta' }: TagProps) => {
   return variant === 'presentation' ? (
-    <div className={containerClassNames(sourceType)} title={title}>
+    <div className={containerClassNames(sourceType, variant)} title={title}>
       <span className="ds:hyphens-auto ds:text-black">{label}</span>
     </div>
   ) : (
-    <button type="button" className={containerClassNames(sourceType)} onClick={onClick} title={title}>
+    <button type="button" className={containerClassNames(sourceType, variant)} onClick={onClick} title={title}>
       <span className="ds:hyphens-auto ds:text-black ds:group-hover:underline">{label}</span>
       <span className="ds:pl-3 ds:text-button-md ds:text-black" aria-hidden>
         {variant === 'selectable' ? <MdAdd size={16} /> : <MdClose size={16} />}

--- a/lib/components/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/lib/components/Tag/__snapshots__/Tag.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Snapshot testing > matches the snapshot 1`] = `
 <div>
   <button
-    class="ds:cursor-pointer ds:group ds:inline-flex ds:select-none ds:items-center ds:rounded-xl ds:text-tag ds:font-arial ds:px-4 ds:py-2 ds:text-left ds:bg-tag-jotain-muuta"
+    class="ds:group ds:inline-flex ds:select-none ds:items-center ds:rounded-xl ds:text-tag ds:font-arial ds:px-4 ds:py-2 ds:text-left ds:cursor-pointer ds:bg-tag-jotain-muuta"
     type="button"
   >
     <span

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier . --write",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "test:unit": "vitest --run",
+    "test:unit-update-snapshot": "vitest --run -u",
     "test:watch": "vitest --watch",
     "storybook": "storybook dev -p 6006 --no-open",
     "storybook:build": "storybook build",


### PR DESCRIPTION
## Description

Updated the Tag component cursor behavior to ensure it does not appear clickable (i.e., no pointer cursor) when `variant === 'presentation'`. This enhances the user interface by reflecting the non-clickable nature of this specific variant.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1451