### PR TITLE
OPHJOD-1600: Update MediaCard's horizontal version

### DIFF
--- a/lib/components/MediaCard/MediaCard.tsx
+++ b/lib/components/MediaCard/MediaCard.tsx
@@ -64,7 +64,7 @@ const Tag = ({
   }>;
 }) => {
   return (
-    <li className="ds:px-2 ds:pb-2 ds:last:pr-0 ds:first:pl-0">
+    <li className="ds:pb-2">
       {Link ? (
         <Link to={to} className="ds:relative ds:z-1">
           {label}
@@ -137,7 +137,7 @@ export const MediaCard = ({
       {isFavorite !== undefined && (
         <FavoriteButton isFavorite={isFavorite} favoriteLabel={favoriteLabel} onFavoriteClick={onFavoriteClick} />
       )}
-      <ul className="ds:text-attrib-value ds:flex ds:flex-row ds:divide-x ds:divide-secondary-5 ds:flex-wrap ds:text-accent ds:pt-3 ds:px-5">
+      <ul className="ds:text-attrib-value ds:flex ds:flex-row ds:divide-x ds:divide-secondary-5 ds:flex-wrap ds:text-accent ds:pt-3 ds:px-5 ds:*:px-2 ds:-mx-2">
         {tags.filter(Boolean).map((tag) => (
           <Tag key={tag.label} linkComponent={Link} {...tag} />
         ))}
@@ -211,7 +211,7 @@ const MediaCardHorizontal = ({
   const { sm } = useMediaQueries();
 
   return (
-    <div className="ds:relative ds:min-h-[137px] ds:w-full ds:overflow-clip ds:rounded ds:shadow-border ds:bg-white ds:grid ds:grid-cols-1 ds:sm:grid-cols-[193px_1fr] ds:lg:grid-cols-[255px_1fr] ds:grid-rows-[1fr_35px]">
+    <div className="ds:relative ds:min-h-[183px] ds:sm:min-h-[156px] ds:lg:min-h-[137px] ds:w-full ds:overflow-clip ds:rounded ds:shadow-border ds:bg-white ds:grid ds:grid-cols-1 ds:sm:grid-cols-[193px_1fr] ds:lg:grid-cols-[255px_1fr] ds:grid-rows-[1fr_auto]">
       <LinkOrDiv
         to={to}
         linkComponent={Link}
@@ -243,7 +243,7 @@ const MediaCardHorizontal = ({
           </div>
         </div>
       </LinkOrDiv>
-      <div className="ds:col-start-1 ds:sm:col-start-2 ds:row-start-2">{children}</div>
+      <div className="ds:col-start-1 ds:sm:col-start-2 ds:md-col-start-1 ds:row-start-2">{children}</div>
     </div>
   );
 };

--- a/lib/components/MediaCard/__snapshots__/MediaCard.test.tsx.snap
+++ b/lib/components/MediaCard/__snapshots__/MediaCard.test.tsx.snap
@@ -36,15 +36,15 @@ exports[`MediaCard > renders the MediaCard component with default vertical varia
     </div>
   </div>
   <ul
-    class="ds:text-attrib-value ds:flex ds:flex-row ds:divide-x ds:divide-secondary-5 ds:flex-wrap ds:text-accent ds:pt-3 ds:px-5"
+    class="ds:text-attrib-value ds:flex ds:flex-row ds:divide-x ds:divide-secondary-5 ds:flex-wrap ds:text-accent ds:pt-3 ds:px-5 ds:*:px-2 ds:-mx-2"
   >
     <li
-      class="ds:px-2 ds:pb-2 ds:last:pr-0 ds:first:pl-0"
+      class="ds:pb-2"
     >
       tag1
     </li>
     <li
-      class="ds:px-2 ds:pb-2 ds:last:pr-0 ds:first:pl-0"
+      class="ds:pb-2"
     >
       tag2
     </li>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Update the MediaCard's horizontal version
- use the min-heights like in the design to get more room in smaller breakpoints
- remove the padding that was caused when tags wrapped to next line

## Notes

There is currently no limit to selected tags or the lengths so it might still break if content producers will write too much.

## Screenshots

### After
### 1024px
<img width="700" alt="SCR-20250521-jkei-2" src="https://github.com/user-attachments/assets/f4ddbe2d-db17-4196-8181-592a16dad64e" />

### 640px
<img width="500" alt="SCR-20250521-jkao-2" src="https://github.com/user-attachments/assets/7b8b3c45-4b6f-4b6f-b191-465bcc83423f" />

### 360px
<img width="300" alt="SCR-20250521-jjwj-2" src="https://github.com/user-attachments/assets/4f905857-50fb-4e65-a800-b2328c750bf3" />



## Before 
### 1024px
<img width="700" alt="SCR-20250521-jmcg-2" src="https://github.com/user-attachments/assets/349218b0-0e81-4cab-9746-d554877f13c3" />

### 640px
<img width="500" alt="SCR-20250521-jlzg-2" src="https://github.com/user-attachments/assets/5d89c542-e33a-446b-90b2-16b00cb56cfb" />

### 360px
<img width="300" alt="SCR-20250521-jluk-2" src="https://github.com/user-attachments/assets/3f4dda7d-5a3b-46b9-91b3-725489e92e43" />



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1600
