### PR TITLE
OPHJOD-1765: Update Note component to match latest design

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -19,7 +19,7 @@ const preview: Preview = {
       },
     },
     viewport: {
-      viewports: {
+      options: {
         mobile: {
           name: 'Mobile',
           styles: {
@@ -40,7 +40,7 @@ const preview: Preview = {
           name: 'Full width',
           styles: {
             width: '100%',
-            height: '100%',
+            height: '300px',
           },
           type: 'desktop',
         },

--- a/lib/components/Note/Note.stories.tsx
+++ b/lib/components/Note/Note.stories.tsx
@@ -2,12 +2,23 @@ import type { StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import type { TitledMeta } from '../../utils';
 
-import { Note } from './Note';
+import { Note, NoteStack, NoteStackProvider, useNoteStack } from '.';
+import { Button } from '../Button/Button';
+import { NoteProps } from './Note';
 
 const meta = {
-  title: 'Content/Note',
+  title: 'Popups/Note',
   component: Note,
   tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    controls: {
+      exclude: ['readMoreComponent', 'onCloseClick'],
+    },
+  },
+  globals: {
+    viewport: { value: 'fullwidth' },
+  },
 } satisfies TitledMeta<typeof Note>;
 
 export default meta;
@@ -26,27 +37,25 @@ const decorators: Story['decorators'] = [
   ),
 ];
 
+const readMoreComponent = <Button variant="plain" label="Lue lisää" className="ds:text-primary-gray!" />;
+
 export const ConfirmationNote: Story = {
   decorators,
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-8714&t=XinajcpkjOyuElVJ-1',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=14337-69983',
     },
     docs: {
       description: {
-        story: 'This is a success toast component for displaying a text.',
+        story: 'This is a success note component for displaying a text.',
       },
-    },
-    layout: 'fullscreen',
-    viewport: {
-      defaultViewport: 'desktop',
     },
   },
   args: {
     title,
     description,
-    readMoreComponent: <>Lue lisää</>,
+    readMoreComponent,
     onCloseClick: fn(),
   },
 };
@@ -56,22 +65,18 @@ export const LongTitleText: Story = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-8803&t=XinajcpkjOyuElVJ-4',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=14337-69983',
     },
     docs: {
       description: {
-        story: 'This is a success toast component for displaying a long title text.',
+        story: 'This is a success note component for displaying a long title text.',
       },
-    },
-    layout: 'fullscreen',
-    viewport: {
-      defaultViewport: 'desktop',
     },
   },
   args: {
     title: 'Lorem ipsum dolor est nonummy noblem ester!',
     description,
-    readMoreComponent: <>Lue lisää</>,
+    readMoreComponent,
     onCloseClick: fn(),
   },
 };
@@ -81,22 +86,19 @@ export const PermanentNote: Story = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-8725&t=XinajcpkjOyuElVJ-4',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=14337-70141',
     },
     docs: {
       description: {
-        story: 'This is a success toast component for displaying a permanent note.',
+        story: 'This is a error note component for displaying a permanent note.',
       },
-    },
-    layout: 'fullscreen',
-    viewport: {
-      defaultViewport: 'desktop',
     },
   },
   args: {
     title,
     description,
-    readMoreComponent: <>Lue lisää</>,
+    variant: 'error',
+    permanent: true,
   },
 };
 
@@ -105,16 +107,12 @@ export const NoCTA: Story = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-8762&t=XinajcpkjOyuElVJ-4',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=14337-70049',
     },
     docs: {
       description: {
-        story: 'This is a success toast component for displaying a permanent note.',
+        story: 'This is a success note component without a call to action.',
       },
-    },
-    layout: 'fullscreen',
-    viewport: {
-      defaultViewport: 'desktop',
     },
   },
   args: {
@@ -129,16 +127,12 @@ export const WarningNote: Story = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=2217-8790&t=XinajcpkjOyuElVJ-4',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=14337-70005',
     },
     docs: {
       description: {
-        story: 'This is a warning toast component for displaying a text.',
+        story: 'This is a warning note component for displaying a text.',
       },
-    },
-    layout: 'fullscreen',
-    viewport: {
-      defaultViewport: 'desktop',
     },
   },
   args: {
@@ -157,17 +151,94 @@ export const ErrorNote: Story = {
     },
     docs: {
       description: {
-        story: 'This is a warning toast component for displaying a text.',
+        story: 'This is a warning note component for displaying a text.',
       },
-    },
-    layout: 'fullscreen',
-    viewport: {
-      defaultViewport: 'desktop',
     },
   },
   args: {
     title,
     description,
     variant: 'error',
+  },
+};
+
+export const feedback: Story = {
+  decorators,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=14337-70080',
+    },
+    docs: {
+      description: {
+        story: 'This is a warning note component for displaying a text.',
+      },
+    },
+  },
+  args: {
+    title,
+    description,
+    variant: 'feedback',
+  },
+};
+
+export const WithNoteStack: Story = {
+  decorators: [
+    (Story) => (
+      <div className="ds:h-[400px] ds:overflow-y-auto">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => {
+    const NoteStackDemo = () => {
+      const { addNote } = useNoteStack();
+      const variants = ['success', 'error', 'warning', 'feedback'] as NoteProps['variant'][];
+      return (
+        <div className="ds:flex ds:flex-col ds:gap-5 ds:relative">
+          <div className="ds:fixed ds:top-0 ds:w-full">
+            <NoteStack showAllText="Näytä kaikki" />
+          </div>
+          <div className="ds:mt-[200px] ds:ml-3 ds:flex ds:gap-5">
+            {variants.map((variant) => (
+              <Button
+                key={variant}
+                variant="accent"
+                size="sm"
+                label={`Add ${variant} note`}
+                onClick={() => addNote({ ...args, variant, title: variant?.toLocaleUpperCase() })}
+              />
+            ))}
+            <Button
+              variant="red-delete"
+              size="sm"
+              label={`Add permanent note`}
+              onClick={() => addNote({ ...args, variant: 'error', title: 'PERMANENT', permanent: true })}
+            />
+          </div>
+        </div>
+      );
+    };
+
+    return (
+      <NoteStackProvider>
+        <NoteStackDemo />
+      </NoteStackProvider>
+    );
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=14337-67043',
+    },
+    docs: {
+      description: {
+        story:
+          'Notes inside a stack component. The stack uses a hook to manage the notes. Notes are sorted by variant and permanent status. When user scrolls the page down, all notes besides permanent ones will collapse. They re-appear if user scrolls to the top of the page. You can add notes by using the provided buttons.',
+      },
+    },
+  },
+  args: {
+    description,
   },
 };

--- a/lib/components/Note/Note.tsx
+++ b/lib/components/Note/Note.tsx
@@ -8,15 +8,24 @@ export interface NoteProps {
   /** Description shown on the note */
   description?: string;
   /** Icon shown on the note */
-  variant?: 'success' | 'warning' | 'error';
+  variant?: 'success' | 'warning' | 'error' | 'feedback';
   /** Callback fired on tap/click of the close button */
   onCloseClick?: () => void;
   /** Component inside the button container if variant is success */
   readMoreComponent?: React.ReactNode;
+  /** If true, the note will always be visible */
+  permanent?: boolean;
 }
 
 /** Dialogs display important information that users need to acknowledge. They appear over the interface and block further interactions. */
-export const Note = ({ title, description, variant = 'success', onCloseClick, readMoreComponent }: NoteProps) => {
+export const Note = ({
+  title,
+  description,
+  variant = 'success',
+  onCloseClick,
+  readMoreComponent,
+  permanent,
+}: NoteProps) => {
   const { sm } = useMediaQueries();
   const hasReadMore = variant === 'success' && readMoreComponent;
   return (
@@ -24,36 +33,25 @@ export const Note = ({ title, description, variant = 'success', onCloseClick, re
       role="alert"
       aria-live="assertive"
       aria-atomic="true"
-      className={cx('ds:text-primary-gray', {
-        'ds:bg-success': variant === 'success',
-        'ds:bg-warning': variant === 'warning',
-        'ds:bg-alert': variant === 'error',
+      className={cx('ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0', {
+        'ds:bg-success ds:text-primary-gray': variant === 'success',
+        'ds:bg-warning ds:text-primary-gray': variant === 'warning',
+        'ds:bg-alert ds:text-white': variant === 'error',
+        'ds:bg-secondary-gray ds:text-white': variant === 'feedback',
       })}
     >
-      <div className="ds:mx-auto ds:flex ds:min-h-[42px] ds:items-center ds:px-5 ds:justify-start ds:sm:min-h-11 ds:sm:pl-7 ds:sm:pr-0 ds:sm:justify-center ds:sm:gap-x-[20%]">
-        <div className="ds:flex ds:flex-col ds:flex-wrap ds:items-start ds:py-4 ds:sm:flex-row ds:sm:items-center ds:sm:gap-x-5 ds:sm:gap-y-2 ds:sm:py-5">
-          <div className="ds:text-heading-4 ds:sm:text-heading-3">{title}</div>
-          <div className="ds:mt-1 ds:sm:mt-0 ds:text-body-sm ds:font-arial">{description}</div>
-          {hasReadMore && !sm && (
-            <span className="ds:mt-4 ds:text-nowrap ds:rounded-[30px] ds:bg-white ds:px-6 ds:py-[10px] ds:text-button-md ds:hover:underline ds:focus-visible:outline ds:focus-visible:outline-[3px] ds:focus-visible:outline-offset-[1.5px] ds:focus-visible:outline-white ds:active:bg-accent ds:active:text-white ds:active:no-underline">
-              {readMoreComponent}
-            </span>
-          )}
+      <div className="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6">
+        <div className="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6">
+          <div className="ds:text-heading-4 ds:text-pretty">{title}</div>
+          <div className="ds:text-body-md ds:font-arial ds:text-pretty">{description}</div>
+          {hasReadMore && !sm && <span className="ds:mt-3">{readMoreComponent}</span>}
         </div>
-        <div className="ds:flex ds:items-center">
-          {hasReadMore && sm && (
-            <span className="ds:mx-7 ds:text-nowrap ds:rounded-[30px] ds:bg-white ds:px-6 ds:py-[10px] ds:text-button-md ds:hover:underline ds:focus-visible:outline ds:focus-visible:outline-[3px] ds:focus-visible:outline-offset-[1.5px] ds:focus-visible:outline-white ds:active:bg-accent ds:active:text-white ds:active:no-underline">
-              {readMoreComponent}
-            </span>
-          )}
-          {onCloseClick && (
-            <button
-              className={`ds:cursor-pointer ds:ml-3 ds:mr-0 ds:flex ds:sm:mr-5 ${hasReadMore ? 'ds:sm:ml-0' : 'ds:sm:ml-5'}`}
-              type="button"
-              aria-label="Close"
-              onClick={onCloseClick}
-            >
-              <JodClose size={32} />
+
+        <div className="ds:flex ds:sm:items-center ds:gap-6 ds:not-sm:self-start">
+          {hasReadMore && sm && readMoreComponent}
+          {onCloseClick && !permanent && (
+            <button className="ds:cursor-pointer ds:flex" type="button" aria-label="Close" onClick={onCloseClick}>
+              <JodClose size={24} />
             </button>
           )}
         </div>

--- a/lib/components/Note/NoteStack.test.tsx
+++ b/lib/components/Note/NoteStack.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, Mock, vi } from 'vitest';
+import { NoteStack } from './NoteStack';
+import * as useNoteStack from './hooks/useNoteStack';
+
+const mockNotes = [
+  { id: '1', title: 'Note 1', description: 'Desc 1', collapsed: false, variant: 'success' },
+  { id: '2', title: 'Note 2', description: 'Desc 2', collapsed: false, variant: 'warning' },
+  { id: '3', title: 'Note 3', description: 'Desc 3', collapsed: true, variant: 'error' },
+];
+
+vi.mock('./hooks/useNoteStack', () => ({
+  useNoteStack: vi.fn(() => ({
+    notes: mockNotes,
+    removeNote: vi.fn(),
+    uncollapseAll: vi.fn(),
+    maxNotes: 2,
+  })),
+}));
+
+describe('NoteStack', () => {
+  const useNoteStackMock = useNoteStack.useNoteStack as Mock;
+
+  it('renders visible notes up to maxNotes', () => {
+    render(<NoteStack showAllText="Show all" />);
+    expect(screen.getByText('Note 1')).toBeInTheDocument();
+    expect(screen.getByText('Note 2')).toBeInTheDocument();
+    expect(screen.queryByText('Note 3')).not.toBeInTheDocument();
+  });
+
+  it('shows the showAll button when there are collapsed notes', () => {
+    render(<NoteStack showAllText="Show all" />);
+    expect(screen.getByRole('button', { name: /Show all/i })).toBeInTheDocument();
+  });
+
+  it('calls uncollapseAll when showAll button is clicked', () => {
+    const uncollapseAll = vi.fn();
+    useNoteStackMock.mockReturnValueOnce({
+      notes: mockNotes,
+      removeNote: vi.fn(),
+      uncollapseAll,
+      maxNotes: 2,
+    });
+    render(<NoteStack showAllText="Show all" />);
+    fireEvent.click(screen.getByRole('button', { name: /Show all/i }));
+    expect(uncollapseAll).toHaveBeenCalled();
+  });
+
+  it('removes note when onCloseClick is triggered', () => {
+    const removeNote = vi.fn();
+    useNoteStackMock.mockReturnValueOnce({
+      notes: mockNotes,
+      removeNote,
+      uncollapseAll: vi.fn(),
+      maxNotes: 2,
+    });
+    render(<NoteStack showAllText="Show all" />);
+    const closeButtons = screen.getAllByRole('button');
+    fireEvent.click(closeButtons[0]);
+    expect(removeNote).toHaveBeenCalled();
+  });
+
+  it('renders notes in correct sort order (permanent first, then by variant)', () => {
+    const notes = [
+      { id: '3', title: 'Warning', collapsed: false, variant: 'warning' },
+      { id: '2', title: 'Error', collapsed: false, variant: 'error' },
+      { id: '4', title: 'Success', collapsed: false, variant: 'success' },
+      { id: '1', title: 'Permanent', collapsed: false, variant: 'success', permanent: true },
+      { id: '5', title: 'Feedback', collapsed: false, variant: 'feedback' },
+    ];
+    useNoteStackMock.mockReturnValueOnce({
+      notes: notes,
+      removeNote: vi.fn(),
+      uncollapseAll: vi.fn(),
+      maxNotes: 5,
+    });
+    render(<NoteStack showAllText="Show all" />);
+    // Find all note titles in the DOM in order
+    const titles = ['Permanent', 'Error', 'Warning', 'Success', 'Feedback'];
+    const foundNodes = titles.map((title) => screen.getByText(title));
+    // Check that the notes appear in the correct order in the DOM
+    expect(foundNodes).toHaveLength(titles.length);
+    expect(foundNodes[0]).toHaveTextContent('Permanent');
+    expect(foundNodes[1]).toHaveTextContent('Error');
+    expect(foundNodes[2]).toHaveTextContent('Warning');
+    expect(foundNodes[3]).toHaveTextContent('Success');
+    expect(foundNodes[4]).toHaveTextContent('Feedback');
+  });
+});

--- a/lib/components/Note/NoteStack.tsx
+++ b/lib/components/Note/NoteStack.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { cx } from '../../cva';
+import { tidyClasses } from '../../utils';
+import { Note } from './Note';
+import { useNoteStack } from './hooks/useNoteStack';
+import { DEFAULT_MAX_NOTES } from './utils';
+
+export interface NoteStackProps {
+  showAllText: string;
+}
+
+export const NoteStack = ({ showAllText }: NoteStackProps) => {
+  const { notes, removeNote, uncollapseAll, maxNotes } = useNoteStack();
+  const safeMaxNotes = typeof maxNotes === 'number' && !isNaN(maxNotes) ? maxNotes : DEFAULT_MAX_NOTES;
+  const visibleNotes = notes.filter((n) => !n.collapsed).slice(0, safeMaxNotes);
+  const collapsedCount = notes.filter((n) => n.collapsed).length;
+
+  const getButtonColors = React.useCallback(() => {
+    const variant = visibleNotes.at(-1)?.variant;
+
+    return !variant
+      ? ''
+      : cx({
+          'ds:bg-alert ds:text-white': variant === 'error',
+          'ds:bg-warning ds:text-primary-gray': variant === 'warning',
+          'ds:bg-success ds:text-primary-gray': variant === 'success',
+          'ds:bg-secondary-gray ds:text-white': variant === 'feedback',
+        });
+  }, [visibleNotes]);
+
+  return (
+    <div className="ds:z-50 ds:flex ds:flex-col ds:relative">
+      {visibleNotes.map((note) => (
+        <Note
+          key={note.id}
+          {...note}
+          onCloseClick={
+            note.onCloseClick
+              ? () => {
+                  note.onCloseClick?.();
+                  removeNote(note.id);
+                }
+              : () => removeNote(note.id)
+          }
+        />
+      ))}
+      {collapsedCount > 0 && visibleNotes.length > 0 && (
+        <button
+          className={tidyClasses([
+            'ds:absolute',
+            'ds:top-full',
+            'ds:right-6',
+            'ds:text-primary-gray',
+            'ds:text-button-sm',
+            'ds:px-6',
+            'ds:py-2',
+            'ds:rounded-b-md',
+            getButtonColors(),
+          ])}
+          onClick={uncollapseAll}
+        >
+          {showAllText} ({notes.length})
+        </button>
+      )}
+    </div>
+  );
+};

--- a/lib/components/Note/__snapshots__/Note.test.tsx.snap
+++ b/lib/components/Note/__snapshots__/Note.test.tsx.snap
@@ -4,41 +4,41 @@ exports[`Note component > renders with close button 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:text-primary-gray ds:bg-success"
+  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-success ds:text-primary-gray"
   role="alert"
 >
   <div
-    class="ds:mx-auto ds:flex ds:min-h-[42px] ds:items-center ds:px-5 ds:justify-start ds:sm:min-h-11 ds:sm:pl-7 ds:sm:pr-0 ds:sm:justify-center ds:sm:gap-x-[20%]"
+    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6"
   >
     <div
-      class="ds:flex ds:flex-col ds:flex-wrap ds:items-start ds:py-4 ds:sm:flex-row ds:sm:items-center ds:sm:gap-x-5 ds:sm:gap-y-2 ds:sm:py-5"
+      class="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6"
     >
       <div
-        class="ds:text-heading-4 ds:sm:text-heading-3"
+        class="ds:text-heading-4 ds:text-pretty"
       >
         Test Title
       </div>
       <div
-        class="ds:mt-1 ds:sm:mt-0 ds:text-body-sm ds:font-arial"
+        class="ds:text-body-md ds:font-arial ds:text-pretty"
       >
         Test Description
       </div>
     </div>
     <div
-      class="ds:flex ds:items-center"
+      class="ds:flex ds:sm:items-center ds:gap-6 ds:not-sm:self-start"
     >
       <button
         aria-label="Close"
-        class="ds:cursor-pointer ds:ml-3 ds:mr-0 ds:flex ds:sm:mr-5 ds:sm:ml-5"
+        class="ds:cursor-pointer ds:flex"
         type="button"
       >
         <svg
           fill="currentColor"
-          height="32"
+          height="24"
           stroke="currentColor"
           stroke-width="0"
           viewBox="0 0 24 24"
-          width="32"
+          width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -56,28 +56,28 @@ exports[`Note component > renders with default variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:text-primary-gray ds:bg-success"
+  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-success ds:text-primary-gray"
   role="alert"
 >
   <div
-    class="ds:mx-auto ds:flex ds:min-h-[42px] ds:items-center ds:px-5 ds:justify-start ds:sm:min-h-11 ds:sm:pl-7 ds:sm:pr-0 ds:sm:justify-center ds:sm:gap-x-[20%]"
+    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6"
   >
     <div
-      class="ds:flex ds:flex-col ds:flex-wrap ds:items-start ds:py-4 ds:sm:flex-row ds:sm:items-center ds:sm:gap-x-5 ds:sm:gap-y-2 ds:sm:py-5"
+      class="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6"
     >
       <div
-        class="ds:text-heading-4 ds:sm:text-heading-3"
+        class="ds:text-heading-4 ds:text-pretty"
       >
         Test Title
       </div>
       <div
-        class="ds:mt-1 ds:sm:mt-0 ds:text-body-sm ds:font-arial"
+        class="ds:text-body-md ds:font-arial ds:text-pretty"
       >
         Test Description
       </div>
     </div>
     <div
-      class="ds:flex ds:items-center"
+      class="ds:flex ds:sm:items-center ds:gap-6 ds:not-sm:self-start"
     />
   </div>
 </div>
@@ -87,28 +87,28 @@ exports[`Note component > renders with error variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:text-primary-gray ds:bg-alert"
+  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-alert ds:text-white"
   role="alert"
 >
   <div
-    class="ds:mx-auto ds:flex ds:min-h-[42px] ds:items-center ds:px-5 ds:justify-start ds:sm:min-h-11 ds:sm:pl-7 ds:sm:pr-0 ds:sm:justify-center ds:sm:gap-x-[20%]"
+    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6"
   >
     <div
-      class="ds:flex ds:flex-col ds:flex-wrap ds:items-start ds:py-4 ds:sm:flex-row ds:sm:items-center ds:sm:gap-x-5 ds:sm:gap-y-2 ds:sm:py-5"
+      class="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6"
     >
       <div
-        class="ds:text-heading-4 ds:sm:text-heading-3"
+        class="ds:text-heading-4 ds:text-pretty"
       >
         Test Title
       </div>
       <div
-        class="ds:mt-1 ds:sm:mt-0 ds:text-body-sm ds:font-arial"
+        class="ds:text-body-md ds:font-arial ds:text-pretty"
       >
         Test Description
       </div>
     </div>
     <div
-      class="ds:flex ds:items-center"
+      class="ds:flex ds:sm:items-center ds:gap-6 ds:not-sm:self-start"
     />
   </div>
 </div>
@@ -118,33 +118,33 @@ exports[`Note component > renders with read more component 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:text-primary-gray ds:bg-success"
+  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-success ds:text-primary-gray"
   role="alert"
 >
   <div
-    class="ds:mx-auto ds:flex ds:min-h-[42px] ds:items-center ds:px-5 ds:justify-start ds:sm:min-h-11 ds:sm:pl-7 ds:sm:pr-0 ds:sm:justify-center ds:sm:gap-x-[20%]"
+    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6"
   >
     <div
-      class="ds:flex ds:flex-col ds:flex-wrap ds:items-start ds:py-4 ds:sm:flex-row ds:sm:items-center ds:sm:gap-x-5 ds:sm:gap-y-2 ds:sm:py-5"
+      class="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6"
     >
       <div
-        class="ds:text-heading-4 ds:sm:text-heading-3"
+        class="ds:text-heading-4 ds:text-pretty"
       >
         Test Title
       </div>
       <div
-        class="ds:mt-1 ds:sm:mt-0 ds:text-body-sm ds:font-arial"
+        class="ds:text-body-md ds:font-arial ds:text-pretty"
       >
         Test Description
       </div>
       <span
-        class="ds:mt-4 ds:text-nowrap ds:rounded-[30px] ds:bg-white ds:px-6 ds:py-[10px] ds:text-button-md ds:hover:underline ds:focus-visible:outline ds:focus-visible:outline-[3px] ds:focus-visible:outline-offset-[1.5px] ds:focus-visible:outline-white ds:active:bg-accent ds:active:text-white ds:active:no-underline"
+        class="ds:mt-3"
       >
         Read more
       </span>
     </div>
     <div
-      class="ds:flex ds:items-center"
+      class="ds:flex ds:sm:items-center ds:gap-6 ds:not-sm:self-start"
     />
   </div>
 </div>
@@ -154,28 +154,28 @@ exports[`Note component > renders with success variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:text-primary-gray ds:bg-success"
+  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-success ds:text-primary-gray"
   role="alert"
 >
   <div
-    class="ds:mx-auto ds:flex ds:min-h-[42px] ds:items-center ds:px-5 ds:justify-start ds:sm:min-h-11 ds:sm:pl-7 ds:sm:pr-0 ds:sm:justify-center ds:sm:gap-x-[20%]"
+    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6"
   >
     <div
-      class="ds:flex ds:flex-col ds:flex-wrap ds:items-start ds:py-4 ds:sm:flex-row ds:sm:items-center ds:sm:gap-x-5 ds:sm:gap-y-2 ds:sm:py-5"
+      class="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6"
     >
       <div
-        class="ds:text-heading-4 ds:sm:text-heading-3"
+        class="ds:text-heading-4 ds:text-pretty"
       >
         Test Title
       </div>
       <div
-        class="ds:mt-1 ds:sm:mt-0 ds:text-body-sm ds:font-arial"
+        class="ds:text-body-md ds:font-arial ds:text-pretty"
       >
         Test Description
       </div>
     </div>
     <div
-      class="ds:flex ds:items-center"
+      class="ds:flex ds:sm:items-center ds:gap-6 ds:not-sm:self-start"
     />
   </div>
 </div>
@@ -185,28 +185,28 @@ exports[`Note component > renders with warning variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:text-primary-gray ds:bg-warning"
+  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-warning ds:text-primary-gray"
   role="alert"
 >
   <div
-    class="ds:mx-auto ds:flex ds:min-h-[42px] ds:items-center ds:px-5 ds:justify-start ds:sm:min-h-11 ds:sm:pl-7 ds:sm:pr-0 ds:sm:justify-center ds:sm:gap-x-[20%]"
+    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6"
   >
     <div
-      class="ds:flex ds:flex-col ds:flex-wrap ds:items-start ds:py-4 ds:sm:flex-row ds:sm:items-center ds:sm:gap-x-5 ds:sm:gap-y-2 ds:sm:py-5"
+      class="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6"
     >
       <div
-        class="ds:text-heading-4 ds:sm:text-heading-3"
+        class="ds:text-heading-4 ds:text-pretty"
       >
         Test Title
       </div>
       <div
-        class="ds:mt-1 ds:sm:mt-0 ds:text-body-sm ds:font-arial"
+        class="ds:text-body-md ds:font-arial ds:text-pretty"
       >
         Test Description
       </div>
     </div>
     <div
-      class="ds:flex ds:items-center"
+      class="ds:flex ds:sm:items-center ds:gap-6 ds:not-sm:self-start"
     />
   </div>
 </div>

--- a/lib/components/Note/hooks/NoteStackContext.tsx
+++ b/lib/components/Note/hooks/NoteStackContext.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { NoteStackNote } from '../utils';
+
+export interface NoteStackContextType {
+  notes: NoteStackNote[];
+  maxNotes?: number;
+  addNote: (note: Omit<NoteStackNote, 'id'>) => string;
+  removeNote: (id: string) => void;
+  uncollapseAll: () => void;
+}
+export const NoteStackContext = React.createContext<NoteStackContextType | undefined>(undefined);

--- a/lib/components/Note/hooks/NoteStackProvider.tsx
+++ b/lib/components/Note/hooks/NoteStackProvider.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { NoteProps } from '../Note';
+import { DEFAULT_MAX_NOTES, NoteStackNote } from '../utils';
+import { NoteStackContext } from './NoteStackContext';
+
+interface NoteStackProviderProps {
+  children: React.ReactNode;
+  // Maximum number of notes
+  maxNotes?: number;
+}
+export const NoteStackProvider = ({ children, maxNotes = DEFAULT_MAX_NOTES }: NoteStackProviderProps) => {
+  const [notes, setNotes] = React.useState<NoteStackNote[]>([]);
+  const idRef = React.useRef(0);
+
+  // Sort function to sort notes by variant. Permanent notes always come first.
+  const sortNotes = (a: NoteStackNote, b: NoteStackNote) => {
+    const order: NoteProps['variant'][] = ['error', 'warning', 'success', 'feedback'];
+    return a.permanent ? -1 : order.indexOf(a.variant) - order.indexOf(b.variant);
+  };
+
+  const addNote = React.useCallback(
+    (note: Omit<NoteStackNote, 'id'>) => {
+      const id = `note-${idRef.current++}`;
+      setNotes((prev) => (notes.length < maxNotes ? [{ ...note, id }, ...prev] : prev).sort(sortNotes));
+      return id;
+    },
+    [maxNotes, notes.length],
+  );
+
+  const removeNote = React.useCallback(
+    (id: string) => {
+      // If the note is permanent, do not remove it
+      if (!notes.find((n) => n.id === id)?.permanent) {
+        setNotes((prev) => prev.filter((n) => n.id !== id));
+      }
+    },
+    [notes],
+  );
+
+  const uncollapseAll = React.useCallback(() => {
+    setNotes((prev) => prev.map((n) => ({ ...n, collapsed: false })));
+  }, []);
+
+  // Collapse all non-permanent notes on scroll
+  const collapseMapper = (collapsed: boolean) => (prev: NoteStackNote[]) =>
+    prev.map((n) => (!n.permanent ? { ...n, collapsed } : n));
+
+  React.useEffect(() => {
+    const onScroll = () => {
+      if (window.scrollY === 0) {
+        // If at the top, uncollapse all notes
+        setNotes(collapseMapper(false));
+      } else {
+        setNotes(collapseMapper(true));
+      }
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const memoizedValue = React.useMemo(
+    () => ({ notes, addNote, removeNote, uncollapseAll, maxNotes }),
+    [addNote, maxNotes, notes, removeNote, uncollapseAll],
+  );
+
+  return <NoteStackContext.Provider value={memoizedValue}>{children}</NoteStackContext.Provider>;
+};

--- a/lib/components/Note/hooks/useNoteStack.tsx
+++ b/lib/components/Note/hooks/useNoteStack.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { NoteStackContext } from './NoteStackContext';
+
+export const useNoteStack = () => {
+  const ctx = React.useContext(NoteStackContext);
+  if (!ctx) {
+    throw new Error('useNoteStack must be used within a NoteStackProvider');
+  }
+  return ctx;
+};

--- a/lib/components/Note/index.ts
+++ b/lib/components/Note/index.ts
@@ -1,0 +1,5 @@
+export { NoteStackContext } from './hooks/NoteStackContext';
+export { NoteStackProvider } from './hooks/NoteStackProvider';
+export { useNoteStack } from './hooks/useNoteStack';
+export { Note } from './Note';
+export { NoteStack, type NoteStackProps } from './NoteStack';

--- a/lib/components/Note/utils.ts
+++ b/lib/components/Note/utils.ts
@@ -1,0 +1,8 @@
+import { NoteProps } from './Note';
+
+export interface NoteStackNote extends NoteProps {
+  id: string;
+  collapsed?: boolean;
+}
+
+export const DEFAULT_MAX_NOTES = 3;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -63,7 +63,7 @@ export {
   type NavigationMenuLanguageSelectionProps,
   type NavigationMenuProps,
 } from './components/NavigationMenu';
-export { Note } from './components/Note/Note';
+export { Note, NoteStack, NoteStackContext, NoteStackProvider, type NoteStackProps } from './components/Note';
 export { Pagination, type PageChangeDetails } from './components/Pagination/Pagination';
 export { PathProgress, type PathProgressStep } from './components/PathProgress/PathProgress';
 export { PopupList, PopupListItem } from './components/PopupList/PopupList';


### PR DESCRIPTION
## Description


* Updated Note component to match latest design.
* Added new feedback variant.
* Moved Note from the "Content" category to "Popups" in Storybook.
* "Read more" component is now unstyled, styling should come from the consuming application.
* Created a NoteStack component and useNoteStack hook for managing multiple notes.
* Notes inside the stack are sorted based on permanent status and variant (permanent first, then error, warning, success and feedback).
* Notes will collapse when user scrolls the page down, and uncollapse when scrolled to the top.
* The stack has a "show all" button when notes are collapsed. The button color is determined by the bottom note variant.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1765

![image](https://github.com/user-attachments/assets/d7961f22-37e4-4e06-9a62-28fb2408a209)

