### PR TITLE
OPHJOD-1769: Add black font color when button variant is white

### DIFF
--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -71,7 +71,7 @@ const getVariantClassName = (
       [`${accentBg} ${pressedBg} ${focusColor} ds:text-white`]: variant === 'accent' && !disabled,
 
       // White
-      [`ds:bg-white ${focusColor} ${hoverColor} ${activeTextColor} ${focusTextColor}`]:
+      [`ds:bg-white ds:text-black ${focusColor} ${hoverColor} ${activeTextColor} ${focusTextColor}`]:
         variant === 'white' && !disabled,
 
       // Plain

--- a/lib/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/lib/components/Button/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button > calls the onClick function when clicked 1`] = `
 <button
-  class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark"
+  class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:text-black ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark"
   type="button"
 >
   <span
@@ -29,7 +29,7 @@ exports[`Button > renders the button as disabled 1`] = `
 
 exports[`Button > renders the button with the correct label 1`] = `
 <button
-  class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark"
+  class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:text-black ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark"
   type="button"
 >
   <span
@@ -42,7 +42,7 @@ exports[`Button > renders the button with the correct label 1`] = `
 
 exports[`Button > renders the button with the correct size 1`] = `
 <button
-  class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-sm ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark"
+  class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-sm ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:text-black ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark"
   type="button"
 >
   <span

--- a/lib/components/HeroCard/__snapshots__/HeroCard.test.tsx.snap
+++ b/lib/components/HeroCard/__snapshots__/HeroCard.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`HeroCard > renders HeroCard with a button 1`] = `
       href="/"
     >
       <span
-        class="ds:inline-flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:pr-4 ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:mt-4 ds:w-fit ds:group-focus:underline ds:group-focus:text-accent"
+        class="ds:inline-flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:pr-4 ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:text-black ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:mt-4 ds:w-fit ds:group-focus:underline ds:group-focus:text-accent"
       >
         <span
           class="ds:group-hover:underline ds:group-active:no-underline ds:group-focus-visible:no-underline ds:py-4"


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Set `ds:text-black` in button for the white variant. The bug was that buttons in HeroCard didn't have visible text (white button, white text). 

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1769
