### PR TITLE
OPHJOD-1714: Add the ability to set a title for menu section and rename props

### DIFF
--- a/lib/components/NavigationMenu/NavigationMenu.stories.tsx
+++ b/lib/components/NavigationMenu/NavigationMenu.stories.tsx
@@ -4,9 +4,9 @@ import { fn } from 'storybook/test';
 import { JodHome } from '../../icons';
 import { Button } from '../Button/Button';
 import { ExternalLinkSection } from './components/ExternalLinkSections';
-import { MenuItem } from './components/MenuList';
+import type { MenuSection } from './components/MenuList';
 import { ServiceVariantProvider } from './hooks/ServiceVariantProvider';
-import { NavigationMenu, NavigationMenuProps } from './NavigationMenu';
+import { NavigationMenu, type NavigationMenuProps } from './NavigationMenu';
 import { LinkComponent } from './types';
 
 const meta = {
@@ -28,103 +28,106 @@ const parameters = {
 
 const DummyLink = (props: LinkComponent) => <a href="/#" {...props} />;
 
-const menuItems: MenuItem[] = [
-  {
-    icon: <JodHome size={24} />,
-    label: 'Osaamispolkuni',
-    LinkComponent: DummyLink,
-    selected: true,
-  },
-  {
-    label: 'Kartoita tilanteesi',
-    // One left in a long form as an example to remind how to use
-    LinkComponent: ({ children, className, ...rest }: LinkComponent) => (
-      <a href="/#" className={className} {...rest}>
-        {children}
-      </a>
-    ),
-    childItems: [
-      {
-        label: 'Kartoita tilanteesi',
-        LinkComponent: DummyLink,
-      },
-      {
-        label: 'Osaamisen kartoitus',
-        LinkComponent: DummyLink,
-      },
-      {
-        label: 'Kiinnostusten kartoitus',
-        LinkComponent: DummyLink,
-      },
-      {
-        label: 'Työ- ja koulutusmahdollisuudet',
-        LinkComponent: DummyLink,
-      },
-    ],
-  },
-  {
-    label: 'Osaamisprofiilini',
-    LinkComponent: DummyLink,
-    childItems: [
-      {
-        label: 'Osaamisprofiilini',
-        LinkComponent: DummyLink,
-      },
-      {
-        label: 'Asetukseni',
-        LinkComponent: DummyLink,
-      },
-      {
-        label: 'Suosikkini',
-        LinkComponent: DummyLink,
-      },
-      {
-        label: 'Päämääräni',
-        LinkComponent: DummyLink,
-      },
-      {
-        label: 'Osaamiseni',
-        LinkComponent: DummyLink,
-        childItems: [
-          {
-            label: 'Työpaikkani',
-            LinkComponent: DummyLink,
-          },
-          {
-            label: 'Koulutukseni',
-            LinkComponent: DummyLink,
-          },
-          {
-            label: 'Vapaa-ajan toimintoni',
-            LinkComponent: DummyLink,
-          },
-          {
-            label: 'Muut osaamiseni',
-            LinkComponent: DummyLink,
-          },
-        ],
-      },
-      {
-        label: 'Kiinnostuksen kohteeni',
-        LinkComponent: DummyLink,
-      },
-      {
-        label: 'Väliotsikko 2',
-      },
-      {
-        label: 'Lorem ipsum 2',
-        LinkComponent: DummyLink,
-      },
-    ],
-  },
-  {
-    label: 'Väliotsikko',
-  },
-  {
-    label: 'Lorem ipsum',
-    LinkComponent: DummyLink,
-  },
-];
+const menuSection: MenuSection = {
+  title: 'Osaamispolkuni',
+  linkItems: [
+    {
+      icon: <JodHome size={24} />,
+      label: 'Osaamispolkuni',
+      LinkComponent: DummyLink,
+      selected: true,
+    },
+    {
+      label: 'Kartoita tilanteesi',
+      // One left in a long form as an example to remind how to use
+      LinkComponent: ({ children, className, ...rest }: LinkComponent) => (
+        <a href="/#" className={className} {...rest}>
+          {children}
+        </a>
+      ),
+      childItems: [
+        {
+          label: 'Kartoita tilanteesi',
+          LinkComponent: DummyLink,
+        },
+        {
+          label: 'Osaamisen kartoitus',
+          LinkComponent: DummyLink,
+        },
+        {
+          label: 'Kiinnostusten kartoitus',
+          LinkComponent: DummyLink,
+        },
+        {
+          label: 'Työ- ja koulutusmahdollisuudet',
+          LinkComponent: DummyLink,
+        },
+      ],
+    },
+    {
+      label: 'Osaamisprofiilini',
+      LinkComponent: DummyLink,
+      childItems: [
+        {
+          label: 'Osaamisprofiilini',
+          LinkComponent: DummyLink,
+        },
+        {
+          label: 'Asetukseni',
+          LinkComponent: DummyLink,
+        },
+        {
+          label: 'Suosikkini',
+          LinkComponent: DummyLink,
+        },
+        {
+          label: 'Päämääräni',
+          LinkComponent: DummyLink,
+        },
+        {
+          label: 'Osaamiseni',
+          LinkComponent: DummyLink,
+          childItems: [
+            {
+              label: 'Työpaikkani',
+              LinkComponent: DummyLink,
+            },
+            {
+              label: 'Koulutukseni',
+              LinkComponent: DummyLink,
+            },
+            {
+              label: 'Vapaa-ajan toimintoni',
+              LinkComponent: DummyLink,
+            },
+            {
+              label: 'Muut osaamiseni',
+              LinkComponent: DummyLink,
+            },
+          ],
+        },
+        {
+          label: 'Kiinnostuksen kohteeni',
+          LinkComponent: DummyLink,
+        },
+        {
+          label: 'Väliotsikko 2',
+        },
+        {
+          label: 'Lorem ipsum 2',
+          LinkComponent: DummyLink,
+        },
+      ],
+    },
+    {
+      label: 'Väliotsikko',
+    },
+    {
+      label: 'Lorem ipsum',
+      LinkComponent: DummyLink,
+    },
+  ],
+};
 
 const externalLinkSections: ExternalLinkSection[] = [
   {
@@ -193,15 +196,15 @@ export const Default: Story = {
     },
   },
   args: {
-    serviceDirectoryLinkLabel: 'Osaamispolkuportaali',
-    ServiceDirectoryLinkComponent: ({ children, className }: LinkComponent) => (
+    portalLinkLabel: 'Osaamispolkuportaali',
+    PortalLinkComponent: ({ children, className }: LinkComponent) => (
       <a href="/#" className={className}>
         {children}
       </a>
     ),
     onClose: fn(),
     open: true,
-    menuItems: menuItems,
+    menuSection: menuSection,
     openSubMenuLabel: 'Avaa alivalikko',
     ariaCloseMenu: 'Sulje valikko',
     externalLinkSections: externalLinkSections,

--- a/lib/components/NavigationMenu/NavigationMenu.test.tsx
+++ b/lib/components/NavigationMenu/NavigationMenu.test.tsx
@@ -26,9 +26,9 @@ describe('NavigationMenu', () => {
   );
 
   const menuProps: NavigationMenuProps = {
-    serviceDirectoryLinkLabel: 'Etusivu',
-    ServiceDirectoryLinkComponent: Link,
-    menuItems: [],
+    portalLinkLabel: 'Etusivu',
+    PortalLinkComponent: Link,
+    menuSection: { linkItems: [] },
     ariaCloseMenu: 'Sulje valikko',
     openSubMenuLabel: 'Avaa alivalikko',
     onClose: vi.fn(),

--- a/lib/components/NavigationMenu/NavigationMenu.tsx
+++ b/lib/components/NavigationMenu/NavigationMenu.tsx
@@ -4,11 +4,11 @@ import { getFocusOutlineClassForService, type ServiceVariant } from '../../utils
 import { Backdrop } from './components/Backdrop';
 import { ExternalLinkSection, ExternalLinkSections } from './components/ExternalLinkSections';
 import { LanguageSelection, LanguageSelectionItem } from './components/LanguageSelection';
-import { MenuItem, MenuList } from './components/MenuList';
+import { MenuList, type MenuSection } from './components/MenuList';
 import { MenuSeparator } from './components/MenuSeparator';
 import { ServiceVariantProvider } from './hooks/ServiceVariantProvider';
 import { useServiceVariant } from './hooks/useServiceVariant';
-import { LinkComponent } from './types';
+import type { LinkComponent } from './types';
 
 const CloseMenuButton = ({ onClick, ariaCloseMenu }: { onClick: () => void; ariaCloseMenu: string }) => {
   const serviceVariant = useServiceVariant();
@@ -33,13 +33,13 @@ interface NavigationMenuBaseProps {
   /** Text for screenreader to have on the close menu button */
   ariaCloseMenu: string;
   /** Text for link that brings user to the front page */
-  serviceDirectoryLinkLabel: string;
+  portalLinkLabel: string;
   /** Icon for the front page link */
-  serviceDirectoryIcon?: React.ReactNode;
+  portalIcon?: React.ReactNode;
   /** Link component to bring user to front page */
-  ServiceDirectoryLinkComponent: React.ComponentType<LinkComponent>;
+  PortalLinkComponent: React.ComponentType<LinkComponent>;
   /** Menu items. Items can have children */
-  menuItems: MenuItem[];
+  menuSection: MenuSection;
   /** Label for button to open submenu of menu item */
   openSubMenuLabel: string;
   /** External link sections */
@@ -61,10 +61,10 @@ export const NavigationMenu = ({
   onClose,
   open,
   ariaCloseMenu,
-  serviceDirectoryLinkLabel,
-  serviceDirectoryIcon,
-  ServiceDirectoryLinkComponent,
-  menuItems,
+  portalLinkLabel,
+  portalIcon,
+  PortalLinkComponent,
+  menuSection,
   openSubMenuLabel,
   externalLinkSections,
   languageSelectionItems,
@@ -97,11 +97,11 @@ export const NavigationMenu = ({
               <CloseMenuButton onClick={onClose} ariaCloseMenu={ariaCloseMenu} />
             </div>
             <MenuList
-              menuItems={menuItems}
+              menuSection={menuSection}
               openSubMenuLabel={openSubMenuLabel}
-              serviceDirectoryLinkLabel={serviceDirectoryLinkLabel}
-              serviceDirectoryIcon={serviceDirectoryIcon}
-              ServiceDirectoryLinkComponent={ServiceDirectoryLinkComponent}
+              portalLinkLabel={portalLinkLabel}
+              portalIcon={portalIcon}
+              PortalLinkComponent={PortalLinkComponent}
             />
             {externalLinkSections && externalLinkSections.length > 0 && (
               <ExternalLinkSections sections={externalLinkSections} />

--- a/lib/components/NavigationMenu/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/components/NavigationMenu/__snapshots__/NavigationMenu.test.tsx.snap
@@ -52,11 +52,9 @@ exports[`NavigationMenu > renders navigation menu with default state 1`] = `
           </span>
         </a>
       </div>
-      <div
-        class="ds:border-l-8 ds:border-secondary-1-dark"
-      >
+      <div>
         <ul
-          class="ds:ml-3 ds:gap-2 ds:flex ds:flex-col"
+          class="ds:gap-2 ds:flex ds:flex-col ds:border-l-8 ds:border-secondary-1-dark"
         />
       </div>
     </div>

--- a/lib/components/NavigationMenu/components/MenuList.tsx
+++ b/lib/components/NavigationMenu/components/MenuList.tsx
@@ -12,7 +12,7 @@ import { LinkComponent } from '../types';
 import { MenuSeparator } from './MenuSeparator';
 import { Placeholder } from './Placeholder';
 
-const ServiceDirectoryLink = ({
+const PortalLink = ({
   label,
   icon,
   selected = false,
@@ -61,6 +61,11 @@ type MenuListItemProps = {
   openSubMenuLabel: string;
 } & MenuItem;
 
+export interface MenuSection {
+  title?: string;
+  linkItems: MenuItem[];
+}
+
 const MenuListItem = ({ label, selected, childItems, LinkComponent, openSubMenuLabel, icon }: MenuListItemProps) => {
   const [nestedMenuOpen, setNestedMenuOpen] = React.useState(false);
   const serviceVariant = useServiceVariant();
@@ -77,7 +82,7 @@ const MenuListItem = ({ label, selected, childItems, LinkComponent, openSubMenuL
 
   return (
     <li data-list-id={label}>
-      <div className="ds:flex ds:flex-row ds:space-between ds:min-h-8 ds:gap-2">
+      <div className="ds:flex ds:flex-row ds:space-between ds:min-h-8 ds:gap-2 ds:ml-3">
         {LinkComponent ? (
           <LinkComponent
             className={`ds:flex-1 ds:flex ${getFocusOutlineClassForService(serviceVariant)} ds:mr-2`}
@@ -149,40 +154,41 @@ const MenuListItem = ({ label, selected, childItems, LinkComponent, openSubMenuL
         )}
       </div>
       {nestedMenuOpen && childItems && childItems.length > 0 && (
-        <MenuList menuItems={childItems} openSubMenuLabel={openSubMenuLabel} menuRef={submenuRef} isNested />
+        <MenuList
+          menuSection={{ linkItems: childItems }}
+          openSubMenuLabel={openSubMenuLabel}
+          menuRef={submenuRef}
+          isNested
+        />
       )}
     </li>
   );
 };
 
 export interface MenuListProps {
-  menuItems: MenuItem[];
+  menuSection: MenuSection;
   menuRef?: React.RefObject<HTMLUListElement | null>;
-  serviceDirectoryLinkLabel?: string;
-  serviceDirectoryIcon?: React.ReactNode;
-  ServiceDirectoryLinkComponent?: React.ComponentType<LinkComponent>;
+  portalLinkLabel?: string;
+  portalIcon?: React.ReactNode;
+  PortalLinkComponent?: React.ComponentType<LinkComponent>;
   isNested?: boolean;
   openSubMenuLabel: string;
 }
 
 export const MenuList = ({
-  serviceDirectoryIcon,
-  ServiceDirectoryLinkComponent,
-  serviceDirectoryLinkLabel,
+  portalIcon,
+  PortalLinkComponent,
+  portalLinkLabel,
   isNested = false,
-  menuItems,
+  menuSection,
   openSubMenuLabel,
   menuRef,
 }: MenuListProps) => {
   const ServiceDirectoryButton = React.useCallback(() => {
-    return serviceDirectoryLinkLabel && ServiceDirectoryLinkComponent ? (
-      <ServiceDirectoryLink
-        label={serviceDirectoryLinkLabel}
-        icon={serviceDirectoryIcon}
-        component={ServiceDirectoryLinkComponent}
-      />
+    return portalLinkLabel && PortalLinkComponent ? (
+      <PortalLink label={portalLinkLabel} icon={portalIcon} component={PortalLinkComponent} />
     ) : null;
-  }, [serviceDirectoryLinkLabel, ServiceDirectoryLinkComponent, serviceDirectoryIcon]);
+  }, [PortalLinkComponent, portalIcon, portalLinkLabel]);
 
   const variant = useServiceVariant();
   const borderClassname = cx({
@@ -196,10 +202,21 @@ export const MenuList = ({
     <>
       {!isNested && <ServiceDirectoryButton />}
       {/* Dont show separator if there are no menu items */}
-      {menuItems.length > 0 && !isNested && <MenuSeparator />}
-      <div className={isNested ? 'ds:ml-6' : `ds:border-l-8 ${borderClassname}`}>
-        <ul className="ds:ml-3 ds:gap-2 ds:flex ds:flex-col" ref={menuRef}>
-          {menuItems.map((item) => (
+      {menuSection.linkItems.length > 0 && !isNested && <MenuSeparator />}
+      <div>
+        {menuSection.title ? (
+          <span className="ds:text-body-sm ds:mb-5 ds:mt-2 ds:flex">{menuSection.title}</span>
+        ) : null}
+        <ul
+          className={tc([
+            'ds:gap-2',
+            'ds:flex',
+            'ds:flex-col',
+            isNested ? 'ds:ml-6' : `ds:border-l-8 ${borderClassname}`,
+          ])}
+          ref={menuRef}
+        >
+          {menuSection.linkItems.map((item) => (
             <MenuListItem
               key={item.label}
               label={item.label}

--- a/lib/components/NavigationMenu/index.ts
+++ b/lib/components/NavigationMenu/index.ts
@@ -4,6 +4,6 @@ export {
   type LanguageSelectionItem,
   type NavigationMenuLanguageSelectionProps,
 } from './components/LanguageSelection';
-export { MenuList, type MenuItem, type MenuListProps } from './components/MenuList';
+export { MenuList, type MenuItem, type MenuListProps, type MenuSection } from './components/MenuList';
 export { NavigationMenu, type NavigationMenuProps } from './NavigationMenu';
 export { type LinkComponent } from './types';


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

* Add the ability to set a title for menu items, and rename `menuItems` prop to `menuSection`.
* Rename incorrectly named serviceDirectory* props to portal* 

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1714

<img width="352" height="161" alt="image" src="https://github.com/user-attachments/assets/e9e5fa2e-e6eb-4171-abac-cc6e35772fe4" />
