### PR TITLE
OPHJOD-1740: Export icons properly

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -62,6 +62,7 @@ export {
   type LinkItem,
   type MenuItem,
   type MenuListProps,
+  type MenuSection,
   type NavigationMenuLanguageSelectionProps,
   type NavigationMenuProps,
 } from './components/NavigationMenu';
@@ -87,4 +88,3 @@ export { Tooltip } from './components/Tooltip/Tooltip';
 export { TooltipContent } from './components/Tooltip/TooltipContent';
 export { TooltipTrigger } from './components/Tooltip/TooltipTrigger';
 export { WizardProgress } from './components/WizardProgress/WizardProgress';
-export * as Icons from './icons';

--- a/package.json
+++ b/package.json
@@ -80,5 +80,15 @@
   },
   "overrides": {
     "storybook": "$storybook"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/main.js",
+      "require": "./dist/main.js"
+    },
+    "./icons": {
+      "import": "./lib/icons/index.js",
+      "require": "./lib/icons/index.js"
+    }
   }
 }


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Noticed that importing the icons in consuming apps was kinda stupid: `import { icons } from '@jod/design-system'` -> `<icons.JodHome />`

Changed the configuration so the imports now work like: `import { JodHome } from '@jod/design-system/icons'`

Tested that this works using `npm link`

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1740
