### PR TITLE
OPHJOD-1784: Fix the logic for "show all" button in note stack

### DIFF
--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -86,7 +86,8 @@ const getVariantClassName = (
         variant === 'white-delete',
 
       // Shared disabled styles
-      [`ds:bg-white ds:text-inactive-gray`]: variant && ['red-delete', 'white'].includes(variant) && disabled,
+      [`ds:bg-white ds:text-inactive-gray`]:
+        variant && ['red-delete', 'white', 'white-delete'].includes(variant) && disabled,
       [`ds:bg-inactive-gray ds:text-secondary-5-light-3`]:
         variant && ['accent', 'red-delete'].includes(variant) && disabled,
     },

--- a/lib/components/Note/Note.tsx
+++ b/lib/components/Note/Note.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { cx } from '../../cva';
 import { useMediaQueries } from '../../hooks/useMediaQueries';
 import { JodClose } from '../../icons';
@@ -15,29 +16,37 @@ export interface NoteProps {
   readMoreComponent?: React.ReactNode;
   /** If true, the note will always be visible */
   permanent?: boolean;
+  /** If true, the note will be collapsed */
+  collapsed?: boolean;
 }
 
 /** Dialogs display important information that users need to acknowledge. They appear over the interface and block further interactions. */
 export const Note = ({
-  title,
+  collapsed,
   description,
-  variant = 'success',
   onCloseClick,
-  readMoreComponent,
   permanent,
+  readMoreComponent,
+  title,
+  variant = 'success',
 }: NoteProps) => {
   const { sm } = useMediaQueries();
   const hasReadMore = variant === 'success' && readMoreComponent;
+
   return (
     <div
       role="alert"
       aria-live="assertive"
       aria-atomic="true"
-      className={cx('ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0', {
+      aria-hidden={collapsed}
+      tabIndex={collapsed ? -1 : undefined}
+      className={cx('ds:text-primary-gray ds:transition-all ds:delay-75 ds:overflow-clip', {
         'ds:bg-success ds:text-primary-gray': variant === 'success',
         'ds:bg-warning ds:text-primary-gray': variant === 'warning',
         'ds:bg-alert ds:text-white': variant === 'error',
         'ds:bg-secondary-gray ds:text-white': variant === 'feedback',
+        'ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8': !collapsed,
+        'ds:h-0': collapsed,
       })}
     >
       <div className="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6">

--- a/lib/components/Note/__snapshots__/Note.test.tsx.snap
+++ b/lib/components/Note/__snapshots__/Note.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Note component > renders with close button 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-success ds:text-primary-gray"
+  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -56,7 +56,7 @@ exports[`Note component > renders with default variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-success ds:text-primary-gray"
+  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -87,7 +87,7 @@ exports[`Note component > renders with error variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-alert ds:text-white"
+  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-alert ds:text-white ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -118,7 +118,7 @@ exports[`Note component > renders with read more component 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-success ds:text-primary-gray"
+  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -154,7 +154,7 @@ exports[`Note component > renders with success variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-success ds:text-primary-gray"
+  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -185,7 +185,7 @@ exports[`Note component > renders with warning variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:bg-warning ds:text-primary-gray"
+  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-warning ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
* Note stack now shows the "show all" in correct color
* Added animation for collapsing
* An unrelated disabled state fix for button

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1784
