### PR TITLE
Open submenu in PageNavigation if any child items are marked as selected

### DIFF
--- a/lib/components/NavigationMenu/components/MenuList.test.tsx
+++ b/lib/components/NavigationMenu/components/MenuList.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LinkComponent } from '../types';
+import { MenuList } from './MenuList';
+
+vi.mock('../../../hooks/useServiceVariant/useServiceVariant', () => ({
+  useServiceVariant: () => 'yksilo',
+}));
+
+const DummyLink = (props: LinkComponent) => (
+  <a href="/#" {...props}>
+    {props.children}
+  </a>
+);
+
+describe('MenuListItem', () => {
+  it('renders a menu item with label', () => {
+    render(<MenuList menuSection={{ linkItems: [{ label: 'Home' }] }} openSubMenuLabel="Open submenu" />);
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('renders a menu item with LinkComponent', () => {
+    render(
+      <MenuList
+        menuSection={{
+          linkItems: [{ label: 'Lorem', LinkComponent: DummyLink }],
+        }}
+        openSubMenuLabel="Open submenu"
+      />,
+    );
+    expect(screen.getByRole('link')).toHaveTextContent('Lorem');
+  });
+
+  it('renders a menu item with childItems and submenu is closed by default', () => {
+    render(
+      <MenuList
+        menuSection={{
+          linkItems: [
+            {
+              label: 'Parent',
+              childItems: [{ label: 'Child' }],
+            },
+          ],
+        }}
+        openSubMenuLabel="Open submenu"
+      />,
+    );
+    expect(screen.getByLabelText('Open submenu')).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Child')).not.toBeInTheDocument();
+  });
+
+  it('opens submenu when button is clicked', () => {
+    render(
+      <MenuList
+        menuSection={{
+          linkItems: [
+            {
+              label: 'Parent',
+              childItems: [{ label: 'Child' }],
+            },
+          ],
+        }}
+        openSubMenuLabel="Open submenu"
+      />,
+    );
+    const button = screen.getByLabelText('Open submenu');
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Child')).toBeInTheDocument();
+  });
+
+  it('applies selected classes for activeIndicator "bg"', () => {
+    render(
+      <MenuList
+        activeIndicator="bg"
+        menuSection={{
+          linkItems: [{ label: 'Selected', selected: true, LinkComponent: DummyLink }],
+        }}
+        openSubMenuLabel="Open submenu"
+      />,
+    );
+    const link = screen.getByRole('link');
+    expect(link.querySelector('span')).toHaveClass('ds:text-white');
+    expect(link.querySelector('span')).toHaveClass('ds:bg-secondary-1-dark');
+  });
+
+  it('applies selected classes for activeIndicator "dot"', () => {
+    render(
+      <MenuList
+        activeIndicator="dot"
+        menuSection={{
+          linkItems: [{ label: 'Selected', selected: true, LinkComponent: DummyLink }],
+        }}
+        openSubMenuLabel="Open submenu"
+      />,
+    );
+    const link = screen.getByRole('link');
+    expect(link.querySelector('span')?.className).toMatch(/ds:before:bg-secondary-1-dark/);
+  });
+
+  it('opens submenu automatically if a child item is selected and collapsed is true', async () => {
+    render(
+      <MenuList
+        menuSection={{
+          linkItems: [
+            {
+              label: 'Parent',
+              childItems: [{ label: 'Child', selected: true, LinkComponent: DummyLink }],
+            },
+          ],
+        }}
+        openSubMenuLabel="Open submenu"
+        collapsed
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText('Open submenu')).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByText('Child')).toBeInTheDocument();
+    });
+  });
+
+  it('does not open submenu automatically if no child is selected and collapsed is true', async () => {
+    render(
+      <MenuList
+        menuSection={{
+          linkItems: [
+            {
+              label: 'Parent',
+              childItems: [{ label: 'Child', selected: false, LinkComponent: DummyLink }],
+            },
+          ],
+        }}
+        openSubMenuLabel="Open submenu"
+        collapsed
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText('Open submenu')).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByText('Child')).not.toBeInTheDocument();
+    });
+  });
+
+  it('opens submenu automatically if collapsed is false', () => {
+    render(
+      <MenuList
+        menuSection={{
+          linkItems: [
+            {
+              label: 'Parent',
+              childItems: [{ label: 'Child', LinkComponent: DummyLink }],
+            },
+          ],
+        }}
+        openSubMenuLabel="Open submenu"
+        collapsed={false}
+      />,
+    );
+    // Submenu should be open regardless of child selection
+    expect(screen.getByLabelText('Open submenu')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Child')).toBeInTheDocument();
+  });
+
+  it('applies custom className to menu item', () => {
+    render(
+      <MenuList
+        menuSection={{
+          linkItems: [{ label: 'CustomClass', className: 'my-custom-class' }],
+        }}
+        openSubMenuLabel="Open submenu"
+        itemClassname="my-custom-class"
+      />,
+    );
+    expect(screen.getByText('CustomClass').parentElement).toHaveClass('my-custom-class');
+  });
+});

--- a/lib/components/NavigationMenu/components/MenuList.tsx
+++ b/lib/components/NavigationMenu/components/MenuList.tsx
@@ -19,10 +19,11 @@ export interface MenuItem {
   childItems?: MenuItem[];
   selected?: boolean;
   className?: string;
+  collapsed?: boolean;
 }
 
 type MenuListItemProps = {
-  openSubMenuLabel: string;
+  openSubMenuLabel?: string;
 } & MenuItem;
 
 export interface MenuSection {
@@ -34,6 +35,7 @@ const MenuListItem = ({
   activeIndicator = 'bg',
   childItems,
   className,
+  collapsed = true,
   icon,
   label,
   LinkComponent,
@@ -43,6 +45,14 @@ const MenuListItem = ({
   const [nestedMenuOpen, setNestedMenuOpen] = React.useState(false);
   const serviceVariant = useServiceVariant();
   const submenuRef = React.useRef<HTMLUListElement>(null);
+
+  React.useEffect(() => {
+    const isChildItemSelected =
+      Array.isArray(childItems) && childItems.length > 0 && childItems?.some((item) => item.selected);
+    if (isChildItemSelected || !collapsed) {
+      setNestedMenuOpen(true);
+    }
+  }, [childItems, collapsed]);
 
   React.useEffect(() => {
     if (nestedMenuOpen && childItems && childItems.length > 0 && submenuRef.current) {
@@ -174,11 +184,13 @@ export interface MenuListProps {
   /** Whether to hide the accent colored border */
   hideAccentBorder?: boolean;
   /** Open submenu label for accessibility */
-  openSubMenuLabel: string;
+  openSubMenuLabel?: string;
   /** Classname for each menu item */
   itemClassname?: string;
   /** Override the service variant from the context provider */
   serviceVariant?: ServiceVariant;
+  /** Is menu collapsed initially */
+  collapsed?: boolean;
 }
 
 export const MenuList = ({
@@ -187,6 +199,7 @@ export const MenuList = ({
   isNested = false,
   itemClassname,
   menuRef,
+  collapsed = true,
   menuSection,
   openSubMenuLabel,
   serviceVariant,
@@ -217,6 +230,7 @@ export const MenuList = ({
             LinkComponent={item.LinkComponent}
             openSubMenuLabel={openSubMenuLabel}
             className={itemClassname}
+            collapsed={collapsed}
           />
         ))}
       </ul>


### PR DESCRIPTION
## Description
* Open submenu in PageNavigation if any child items are marked as selected. Makes navigation on subpages more pleasant.
* Introduced a prop for uncollapsing the whole menu.
## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1795
