### PR TITLE
OPHJOD-1826: Add aria-label for the Button

### DIFF
--- a/lib/components/Button/Button.stories.tsx
+++ b/lib/components/Button/Button.stories.tsx
@@ -251,3 +251,20 @@ export const AsLink: Story = {
     LinkComponent: ({ children }: { children: React.ReactNode }) => <a href="/#">{children}</a>,
   },
 };
+
+export const OnlyIcon: Story = {
+  parameters: {
+    design,
+    docs: {
+      description: {
+        story: 'This is a large button component with an left icon.',
+      },
+    },
+  },
+  args: {
+    label: 'Takaisin',
+    onClick: fn(),
+    variant: 'white',
+    icon: <JodArrowLeft size={24} />,
+  },
+};

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -156,7 +156,7 @@ export const Button = ({
 
   return LinkComponent ? (
     <LinkComponent>
-      <span className={`${buttonClassName} ${className ?? ''}`.trim()}>
+      <span className={`${buttonClassName} ${className ?? ''}`.trim()} aria-label={label}>
         {leftIcon && icon}
         {onlyIcon ? icon : <span className={spanClassName}>{label}</span>}
         {rightIcon && icon}
@@ -164,6 +164,7 @@ export const Button = ({
     </LinkComponent>
   ) : (
     <button
+      aria-label={label}
       form={form}
       disabled={disabled}
       type={onClick ? 'button' : 'submit'}

--- a/lib/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/lib/components/Button/__snapshots__/Button.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Button > calls the onClick function when clicked 1`] = `
 <button
+  aria-label="Click me"
   class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:text-black ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark"
   type="button"
 >
@@ -15,6 +16,7 @@ exports[`Button > calls the onClick function when clicked 1`] = `
 
 exports[`Button > renders the button as disabled 1`] = `
 <button
+  aria-label="Click me"
   class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:text-inactive-gray"
   disabled=""
   type="button"
@@ -29,6 +31,7 @@ exports[`Button > renders the button as disabled 1`] = `
 
 exports[`Button > renders the button with the correct label 1`] = `
 <button
+  aria-label="Click me"
   class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:text-black ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark"
   type="button"
 >
@@ -42,6 +45,7 @@ exports[`Button > renders the button with the correct label 1`] = `
 
 exports[`Button > renders the button with the correct size 1`] = `
 <button
+  aria-label="Click me"
   class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-sm ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:text-black ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark"
   type="button"
 >
@@ -55,6 +59,7 @@ exports[`Button > renders the button with the correct size 1`] = `
 
 exports[`Button > renders the button with the correct variant 1`] = `
 <button
+  aria-label="Click me"
   class="ds:flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-secondary-1-dark ds:active:bg-secondary-1-dark-2 ds:focus-visible:outline-secondary-1-dark ds:text-white"
   type="button"
 >

--- a/lib/components/HeroCard/__snapshots__/HeroCard.test.tsx.snap
+++ b/lib/components/HeroCard/__snapshots__/HeroCard.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`HeroCard > renders HeroCard with a button 1`] = `
       href="/"
     >
       <span
+        aria-label="Test Button Label"
         class="ds:inline-flex ds:cursor-pointer ds:px-6 ds:rounded-[30px] ds:items-center ds:gap-4 ds:select-none ds:group ds:pr-4 ds:text-button-md ds:active:underline ds:focus-visible:underline ds:hover:not-disabled:underline ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:bg-white ds:text-black ds:focus-visible:outline-secondary-1-dark ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:mt-4 ds:w-fit ds:group-focus:underline ds:group-focus:text-accent"
       >
         <span


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Add `aria-label` for a Button component.

When using only the icon mode, screenreader user couldn't know what is the button for. Uses the same label that is already required, so no functionality changed.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1826
