### PR TITLE
OPHJOD-1858: Fix MenuList focus stealing issue

### DIFF
--- a/lib/components/NavigationMenu/components/MenuList.tsx
+++ b/lib/components/NavigationMenu/components/MenuList.tsx
@@ -43,6 +43,7 @@ const MenuListItem = ({
   selected,
 }: MenuListItemProps) => {
   const [nestedMenuOpen, setNestedMenuOpen] = React.useState(false);
+  const [shouldFocusFirstChild, setShouldFocusFirstChild] = React.useState(false);
   const serviceVariant = useServiceVariant();
   const submenuRef = React.useRef<HTMLUListElement>(null);
 
@@ -55,13 +56,23 @@ const MenuListItem = ({
   }, [childItems, collapsed]);
 
   React.useEffect(() => {
-    if (nestedMenuOpen && childItems && childItems.length > 0 && submenuRef.current) {
+    if (shouldFocusFirstChild && nestedMenuOpen && submenuRef.current) {
       const firstChildLink = submenuRef.current.querySelector('a');
       if (firstChildLink instanceof HTMLElement) {
         firstChildLink.focus();
       }
+      setShouldFocusFirstChild(false);
     }
-  }, [nestedMenuOpen, childItems]);
+  }, [shouldFocusFirstChild, nestedMenuOpen]);
+
+  const handleNestedMenuOpen = () => {
+    const isOpening = !nestedMenuOpen;
+    setNestedMenuOpen(isOpening);
+
+    if (isOpening && childItems && childItems.length > 0) {
+      setShouldFocusFirstChild(true);
+    }
+  };
 
   const getSelectedClasses = () => {
     if (activeIndicator === 'dot') {
@@ -152,9 +163,7 @@ const MenuListItem = ({
               'ds:before:bg-bg-gray-2',
               'ds:before:pointer-events-none',
             ])}
-            onClick={() => {
-              setNestedMenuOpen(!nestedMenuOpen);
-            }}
+            onClick={handleNestedMenuOpen}
           >
             {nestedMenuOpen ? <JodCaretUp /> : <JodCaretDown />}
           </button>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Fix the focus stealing of MenuList.

Example case where it was causing issue is when used in yksilo-ui and having the submenu. It stealed the focus to always first item in the list on every page refresh.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1858
https://jira.eduuni.fi/browse/OPHJOD-1840
