### PR TITLE
OPHJOD-1766: Fix collapsing issues with NoteStack

### DIFF
--- a/lib/components/NavigationBar/NavigationBar.tsx
+++ b/lib/components/NavigationBar/NavigationBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useCollapseOnScroll } from '../../hooks/useCollapseOnScroll';
 import { useMediaQueries } from '../../hooks/useMediaQueries';
 import { getAccentBgClassForService, type ServiceVariant, tidyClasses as tc } from '../../utils';
 import { LogoIconRgb } from '../Logo/LogoIcon';
@@ -71,48 +72,20 @@ export const NavigationBar = ({
   serviceBarContent,
 }: NavigationBarProps) => {
   const { sm } = useMediaQueries();
-  const [scrolled, setScrolled] = React.useState(false);
-  const prevScrollYRef = React.useRef(0);
-  const animPendingRef = React.useRef(false);
+  const [serviceBarCollapsed, setServiceBarCollapsed] = React.useState(false);
 
-  React.useEffect(() => {
-    let timeout: number | null = null;
-
-    const startTimer = () => {
-      const animationPending = animPendingRef.current;
-      if (animationPending) {
-        return;
-      }
-      animPendingRef.current = true;
-
-      timeout = window.setTimeout(() => {
-        animPendingRef.current = false;
-      }, 200);
-    };
-    const handleScroll = () => {
-      const animationPending = animPendingRef.current;
-      const prevScrollY = prevScrollYRef.current;
-
-      if (animationPending) {
-        return;
-      }
-
-      if (prevScrollY === 0 && window.scrollY > 0) {
-        setScrolled(true);
-        startTimer();
-      } else if (prevScrollY > 0 && window.scrollY === 0) {
-        setScrolled(false);
-      }
-      prevScrollYRef.current = window.scrollY;
-    };
-    window.addEventListener('scroll', handleScroll);
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-    };
+  const onCollapse = React.useCallback(() => {
+    setServiceBarCollapsed(true);
   }, []);
+
+  const onUncollapse = React.useCallback(() => {
+    setServiceBarCollapsed(false);
+  }, []);
+
+  useCollapseOnScroll({
+    onCollapse,
+    onUncollapse,
+  });
 
   const serviceBarContents = (
     <>
@@ -161,11 +134,11 @@ export const NavigationBar = ({
             'ds:sm:text-[14px]',
             'ds:transition-[height]',
             'ds:duration-100',
-            scrolled ? 'ds:h-2' : 'ds:h-8',
+            serviceBarCollapsed ? 'ds:h-2' : 'ds:h-8',
             getAccentBgClassForService(serviceBarVariant),
           ])}
         >
-          {scrolled ? null : serviceBarContents}
+          {serviceBarCollapsed ? null : serviceBarContents}
         </div>
       )}
     </>

--- a/lib/components/Note/Note.tsx
+++ b/lib/components/Note/Note.tsx
@@ -40,7 +40,7 @@ export const Note = ({
       aria-atomic="true"
       aria-hidden={collapsed}
       tabIndex={collapsed ? -1 : undefined}
-      className={cx('ds:text-primary-gray ds:transition-all ds:delay-75 ds:overflow-clip', {
+      className={cx('ds:text-primary-gray ds:transition-[height] ds:duration-100 ds:overflow-clip', {
         'ds:bg-success ds:text-primary-gray': variant === 'success',
         'ds:bg-warning ds:text-primary-gray': variant === 'warning',
         'ds:bg-alert ds:text-white': variant === 'error',

--- a/lib/components/Note/NoteStack.test.tsx
+++ b/lib/components/Note/NoteStack.test.tsx
@@ -29,11 +29,7 @@ describe('NoteStack', () => {
     render(<NoteStack showAllText="Show all" />);
     expect(screen.getByText('Note 1')).toBeInTheDocument();
     expect(screen.getByText('Note 2')).toBeInTheDocument();
-    const note3 = screen.queryByText('Note 3');
-    expect(note3).toBeInTheDocument();
-    const note3Container = note3?.closest('[aria-hidden="true"]');
-    expect(note3Container).toBeTruthy();
-    expect(note3Container).toHaveAttribute('tabIndex', '-1');
+    expect(screen.queryByText('Note 3')).not.toBeInTheDocument();
   });
 
   it('shows the showAll button when there are collapsed notes', async () => {

--- a/lib/components/Note/NoteStack.tsx
+++ b/lib/components/Note/NoteStack.tsx
@@ -1,32 +1,37 @@
 import React from 'react';
 import { cx } from '../../cva';
+import { useCollapseOnScroll } from '../../hooks/useCollapseOnScroll';
 import { tidyClasses } from '../../utils';
 import { Note } from './Note';
 import { useNoteStack } from './hooks/useNoteStack';
+import { DEFAULT_MAX_NOTES, type NoteStackNote } from './utils';
 
 export interface NoteStackProps {
   showAllText: string;
 }
 
 export const NoteStack = ({ showAllText }: NoteStackProps) => {
-  const { notes, removeNote, uncollapseAll } = useNoteStack();
-
+  const { notes, setNotes, removeNote, uncollapseAll, maxNotes = DEFAULT_MAX_NOTES } = useNoteStack();
+  const [ignoreScroll, setIgnoreScroll] = React.useState(false);
   const collapsedCount = notes.filter((n) => n.collapsed).length;
-  const [buttonVisible, setButtonVisible] = React.useState(false);
 
-  React.useEffect(() => {
-    if (collapsedCount > 0) {
-      setButtonVisible(false);
-      setTimeout(() => {
-        setButtonVisible(true);
-      }, 150);
-    } else {
-      setButtonVisible(true);
-      setTimeout(() => {
-        setButtonVisible(false);
-      }, 150);
-    }
-  }, [collapsedCount]);
+  const onCollapse = React.useCallback(() => {
+    setNotes(collapseMapper(true));
+  }, [setNotes]);
+
+  const onUncollapse = React.useCallback(() => {
+    setNotes(collapseMapper(false));
+  }, [setNotes]);
+
+  // Collapse all non-permanent notes on scroll
+  const collapseMapper = (collapsed: boolean) => (prev: NoteStackNote[]) =>
+    prev.map((n) => (n.permanent ? { ...n, collapsed: false } : { ...n, collapsed }));
+
+  useCollapseOnScroll({
+    onCollapse,
+    onUncollapse,
+    ignoreScroll,
+  });
 
   const getButtonColors = React.useCallback(() => {
     // If any note is permanent, use error  variant, otherwise use the last note's variant
@@ -44,40 +49,47 @@ export const NoteStack = ({ showAllText }: NoteStackProps) => {
 
   return (
     <div className="ds:z-50 ds:flex ds:flex-col ds:relative">
-      {notes.map((note) => (
+      {notes.slice(0, maxNotes).map((note) => (
         <Note
           key={note.id}
           collapsed={note.collapsed}
           {...note}
-          onCloseClick={
-            note.onCloseClick
-              ? () => {
-                  note.onCloseClick?.();
-                  removeNote(note.id);
-                }
-              : () => removeNote(note.id)
-          }
+          onCloseClick={() => {
+            note.onCloseClick?.();
+            removeNote(note.id);
+          }}
         />
       ))}
-      {collapsedCount > 0 && buttonVisible && (
-        <button
-          className={tidyClasses([
-            'ds:cursor-pointer',
-            'ds:absolute',
-            'ds:top-full',
-            'ds:right-6',
-            'ds:text-primary-gray',
-            'ds:text-button-sm',
-            'ds:px-6',
-            'ds:py-2',
-            'ds:rounded-b-md',
-            getButtonColors(),
-          ])}
-          onClick={uncollapseAll}
-        >
-          {showAllText} ({notes.length})
-        </button>
-      )}
+
+      <button
+        aria-hidden={collapsedCount === 0}
+        tabIndex={collapsedCount === 0 ? -1 : 0}
+        className={tidyClasses([
+          'ds:cursor-pointer',
+          'ds:absolute',
+          'ds:top-full',
+          'ds:right-6',
+          'ds:text-primary-gray',
+          'ds:text-button-sm',
+          'ds:px-6',
+          'ds:rounded-b-md',
+          'ds:transition-[height]',
+          'ds:duration-100',
+          collapsedCount > 0 ? 'ds:py-2 ds:h-7' : 'ds:py-0 ds:h-0',
+          getButtonColors(),
+        ])}
+        onClick={() => {
+          // Scroll events need to be ignored for the duration of the collapse animation
+          // to prevent instant uncollapsing when scrollY > 0
+          setIgnoreScroll(true);
+          uncollapseAll();
+          setTimeout(() => {
+            setIgnoreScroll(false);
+          }, 200);
+        }}
+      >
+        <span className={collapsedCount === 0 ? 'ds:hidden' : ''}>{`${showAllText} (${notes.length})`}</span>
+      </button>
     </div>
   );
 };

--- a/lib/components/Note/__snapshots__/Note.test.tsx.snap
+++ b/lib/components/Note/__snapshots__/Note.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Note component > renders with close button 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
+  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -56,7 +56,7 @@ exports[`Note component > renders with default variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
+  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -87,7 +87,7 @@ exports[`Note component > renders with error variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-alert ds:text-white ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
+  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-alert ds:text-white ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -118,7 +118,7 @@ exports[`Note component > renders with read more component 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
+  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -154,7 +154,7 @@ exports[`Note component > renders with success variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
+  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div
@@ -185,7 +185,7 @@ exports[`Note component > renders with warning variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:transition-all ds:delay-75 ds:overflow-clip ds:bg-warning ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
+  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-warning ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
   role="alert"
 >
   <div

--- a/lib/components/Note/hooks/NoteStackContext.tsx
+++ b/lib/components/Note/hooks/NoteStackContext.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { NoteStackNote } from '../utils';
+import type { NewNoteStackItem, NoteStackNote } from '../utils';
 
 export interface NoteStackContextType {
   notes: NoteStackNote[];
   maxNotes?: number;
-  addNote: (note: Omit<NoteStackNote, 'id'>) => string;
+  addNote: (note: NewNoteStackItem) => void;
+  setNotes: React.Dispatch<React.SetStateAction<NoteStackNote[]>>;
   removeNote: (id: string) => void;
   uncollapseAll: () => void;
 }

--- a/lib/components/Note/index.ts
+++ b/lib/components/Note/index.ts
@@ -1,5 +1,6 @@
-export { NoteStackContext } from './hooks/NoteStackContext';
+export { NoteStackContext, type NoteStackContextType } from './hooks/NoteStackContext';
 export { NoteStackProvider } from './hooks/NoteStackProvider';
 export { useNoteStack } from './hooks/useNoteStack';
 export { Note } from './Note';
 export { NoteStack, type NoteStackProps } from './NoteStack';
+export type { NoteStackNote } from './utils';

--- a/lib/components/Note/utils.ts
+++ b/lib/components/Note/utils.ts
@@ -5,4 +5,9 @@ export interface NoteStackNote extends NoteProps {
   collapsed?: boolean;
 }
 
+export type NewNoteStackItem = Pick<NoteProps, 'title' | 'description' | 'variant'> & {
+  id?: string;
+  permanent?: boolean;
+};
+
 export const DEFAULT_MAX_NOTES = 3;

--- a/lib/hooks/useCollapseOnScroll/index.ts
+++ b/lib/hooks/useCollapseOnScroll/index.ts
@@ -1,0 +1,69 @@
+import React from 'react';
+
+export interface UseCollapseOnScrollProps {
+  onCollapse: () => void;
+  onUncollapse: () => void;
+  ignoreScroll?: boolean;
+  animationDuration?: number;
+  topThreshold?: number;
+}
+
+export const useCollapseOnScroll = ({
+  onCollapse,
+  onUncollapse,
+  ignoreScroll = false,
+  animationDuration = 100,
+  topThreshold = 0,
+}: UseCollapseOnScrollProps) => {
+  const animPendingRef = React.useRef(false);
+  const timeoutRef = React.useRef<number | null>(null);
+  const requestAnimationFrameRef = React.useRef<number | null>(null);
+  const isCollapsedRef = React.useRef(false);
+  const ticking = React.useRef(false);
+
+  React.useEffect(() => {
+    // Call collapse/uncollapse based on the scroll position
+    const checkScroll = () => {
+      ticking.current = false;
+
+      if (ignoreScroll || animPendingRef.current) {
+        return;
+      }
+
+      const atTop = window.scrollY <= topThreshold;
+
+      if (!atTop && !isCollapsedRef.current) {
+        onCollapse();
+        isCollapsedRef.current = true;
+        animPendingRef.current = true;
+        timeoutRef.current = window.setTimeout(() => {
+          animPendingRef.current = false;
+        }, animationDuration);
+      } else if (atTop && isCollapsedRef.current) {
+        onUncollapse();
+        isCollapsedRef.current = false;
+      }
+    };
+
+    // Use requestAnimationFrame for more precise scroll position detection
+    const handleScroll = () => {
+      if (!ticking.current) {
+        requestAnimationFrameRef.current = window.requestAnimationFrame(checkScroll);
+        ticking.current = true;
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      if (requestAnimationFrameRef.current) {
+        window.cancelAnimationFrame(requestAnimationFrameRef.current);
+        requestAnimationFrameRef.current = null;
+      }
+    };
+  }, [animationDuration, ignoreScroll, onCollapse, onUncollapse, topThreshold]);
+};

--- a/lib/hooks/useCollapseOnScroll/useCollapseOnScroll.test.ts
+++ b/lib/hooks/useCollapseOnScroll/useCollapseOnScroll.test.ts
@@ -1,0 +1,199 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCollapseOnScroll } from '.';
+
+describe('useCollapseOnScroll', () => {
+  let onCollapseMock = vi.fn();
+  let onUncollapseMock = vi.fn();
+  const originalScrollY = window.scrollY;
+
+  beforeEach(() => {
+    onCollapseMock = vi.fn();
+    onUncollapseMock = vi.fn();
+
+    Object.defineProperty(window, 'scrollY', {
+      writable: true,
+      configurable: true,
+      value: 0,
+    });
+
+    vi.useFakeTimers();
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      return window.setTimeout(() => cb(performance.now()), 17);
+    });
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    onCollapseMock.mockClear();
+    onUncollapseMock.mockClear();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+
+    Object.defineProperty(window, 'scrollY', {
+      writable: true,
+      configurable: true,
+      value: originalScrollY,
+    });
+  });
+
+  const simulateScroll = (scrollYValue: number) => {
+    Object.defineProperty(window, 'scrollY', { value: scrollYValue });
+    window.dispatchEvent(new Event('scroll'));
+    vi.advanceTimersByTime(100);
+  };
+
+  it('should not collapse on initial render', () => {
+    renderHook(() =>
+      useCollapseOnScroll({
+        onCollapse: onCollapseMock,
+        onUncollapse: onUncollapseMock,
+      }),
+    );
+
+    expect(onCollapseMock).not.toHaveBeenCalled();
+    expect(onUncollapseMock).not.toHaveBeenCalled();
+  });
+
+  it('should collapse when scrolling past the top threshold', () => {
+    const topThreshold = 16;
+    renderHook(() =>
+      useCollapseOnScroll({
+        onCollapse: onCollapseMock,
+        onUncollapse: onUncollapseMock,
+        topThreshold,
+      }),
+    );
+
+    act(() => {
+      simulateScroll(topThreshold + 1);
+    });
+
+    expect(onCollapseMock).toHaveBeenCalledTimes(1);
+    expect(onUncollapseMock).not.toHaveBeenCalled();
+  });
+
+  it('should not call onCollapse if already collapsed', () => {
+    const topThreshold = 16;
+    renderHook(() =>
+      useCollapseOnScroll({
+        onCollapse: onCollapseMock,
+        onUncollapse: onUncollapseMock,
+        topThreshold,
+      }),
+    );
+
+    // Collapse
+    act(() => {
+      simulateScroll(topThreshold + 1);
+    });
+    expect(onCollapseMock).toHaveBeenCalledTimes(1);
+
+    // Scroll further down, should not collapse again
+    act(() => {
+      simulateScroll(100);
+    });
+
+    expect(onCollapseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call onUncollapse if already uncollapsed', () => {
+    const topThreshold = 16;
+    renderHook(() =>
+      useCollapseOnScroll({
+        onCollapse: onCollapseMock,
+        onUncollapse: onUncollapseMock,
+        topThreshold,
+      }),
+    );
+
+    // Collapse and uncollapse
+    act(() => {
+      simulateScroll(topThreshold + 1);
+    });
+    act(() => {
+      simulateScroll(10);
+    });
+    expect(onUncollapseMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      simulateScroll(0);
+    });
+    expect(onUncollapseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore scroll events when ignoreScroll is true', () => {
+    const topThreshold = 16;
+    renderHook(() =>
+      useCollapseOnScroll({
+        onCollapse: onCollapseMock,
+        onUncollapse: onUncollapseMock,
+        ignoreScroll: true,
+        topThreshold,
+      }),
+    );
+
+    act(() => {
+      simulateScroll(topThreshold + 1);
+    });
+
+    expect(onCollapseMock).not.toHaveBeenCalled();
+    expect(onUncollapseMock).not.toHaveBeenCalled();
+  });
+
+  it('should handle animation duration correctly and prevent multiple calls', () => {
+    const animationDuration = 500;
+    const topThreshold = 16;
+    renderHook(() =>
+      useCollapseOnScroll({
+        onCollapse: onCollapseMock,
+        onUncollapse: onUncollapseMock,
+        animationDuration,
+        topThreshold,
+      }),
+    );
+
+    // First scroll to collapse
+    act(() => {
+      simulateScroll(topThreshold + 1);
+    });
+    expect(onCollapseMock).toHaveBeenCalledTimes(1);
+
+    // Scroll again before the animation timeout
+    act(() => {
+      simulateScroll(100);
+    });
+    expect(onCollapseMock).toHaveBeenCalledTimes(1);
+
+    // Scroll again, now it should allow a new collapse call (though it won't due to state)
+    // The key here is to test the animPendingRef state is reset.
+    act(() => {
+      simulateScroll(101);
+    });
+    expect(onCollapseMock).toHaveBeenCalledTimes(1); // Still 1 because it's already collapsed
+  });
+
+  it('should clean up event listeners and timeouts on unmount', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame');
+
+    const { unmount } = renderHook(() =>
+      useCollapseOnScroll({
+        onCollapse: onCollapseMock,
+        onUncollapse: onUncollapseMock,
+      }),
+    );
+
+    act(() => {
+      simulateScroll(100);
+    });
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+  });
+});

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -74,7 +74,7 @@ export {
   NoteStackContext,
   NoteStackProvider,
   useNoteStack,
-  type NoteStackProps,
+  type NoteStackNote,
 } from './components/Note';
 export { PageNavigation, type PageNavigationProps } from './components/PageNavigation/PageNavigation';
 export { Pagination, type PageChangeDetails } from './components/Pagination/Pagination';


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
When I started implementing `NoteStack` in yksilö UI, I ran into several issues, which are fixed in this PR:
* When doing small scrolls at the top of the page, notes might collapse and uncollapse immidiately due to animations.
* When user has scrolled further down and pressed the "Show all" button, it would immidiately collapse notes.
* Added animation to make the "show all" button appearance more smooth.
* Use a queue system when adding notes to the stack, this allows efficient prevention of duplicate notes.
* Create `useCollapseOnScroll` hook to prevent code duplication, as collapsing is used in both `NoteStack` and `NavigationBar`

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1766
