### PR TITLE
OPHJOD-1895: Show navigation menu on the left side of the screen

### DIFF
--- a/lib/components/NavigationMenu/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/components/NavigationMenu/__snapshots__/NavigationMenu.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`NavigationMenu > renders navigation menu with default state 1`] = `
 <dialog
-  class="ds:-z-1 ds:flex ds:backdrop:bg-black/20 ds:w-[370px] ds:max-w-full ds:max-h-screen ds:min-h-full ds:overflow-auto ds:overscroll-contain ds:hyphens-auto"
+  class="ds:fixed ds:left-auto ds:right-0 ds:-z-1 ds:flex ds:backdrop:bg-black/20 ds:w-[370px] ds:max-w-full ds:max-h-screen ds:min-h-full ds:overflow-auto ds:overscroll-contain ds:hyphens-auto"
   open=""
 >
   <nav

--- a/lib/components/NavigationMenu/components/Backdrop.tsx
+++ b/lib/components/NavigationMenu/components/Backdrop.tsx
@@ -23,7 +23,7 @@ export const Backdrop = ({ children, dialogRef, onClose }: BackdropProps) => {
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <dialog
       ref={dialogRef}
-      className="ds:-z-1 ds:flex ds:backdrop:bg-black/20 ds:w-[370px] ds:max-w-full ds:max-h-screen ds:min-h-full ds:overflow-auto ds:overscroll-contain ds:hyphens-auto"
+      className="ds:fixed ds:left-auto ds:right-0 ds:-z-1 ds:flex ds:backdrop:bg-black/20 ds:w-[370px] ds:max-w-full ds:max-h-screen ds:min-h-full ds:overflow-auto ds:overscroll-contain ds:hyphens-auto"
       onKeyDown={handleKeyDown}
       onClick={handleClickOutside}
     >


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Display `NavigationMenu` on the right side of the screen. Tested via `npm link` in yksilö UI

<img width="1254" height="662" alt="image" src="https://github.com/user-attachments/assets/557a2d54-f157-46c3-b35c-a034f479f0ce" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1895
