### PR TITLE
OPHJOD-1953: Fix sm button size and reintroduce gray button variant

### DIFF
--- a/lib/components/Button/Button.stories.tsx
+++ b/lib/components/Button/Button.stories.tsx
@@ -64,6 +64,11 @@ export const AllVariants: Story = {
         cmp: <Button {...args} variant="white-delete" size="sm" />,
         cmpDisabled: <Button {...args} variant="white-delete" size="sm" disabled />,
       },
+      {
+        label: 'Gray',
+        cmp: <Button {...args} variant="gray" size="sm" />,
+        cmpDisabled: <Button {...args} variant="gray" size="sm" disabled />,
+      },
     ];
 
     const lgButtons = [
@@ -91,6 +96,11 @@ export const AllVariants: Story = {
         label: 'White Delete (danger secondary)',
         cmp: <Button {...args} variant="white-delete" size="lg" />,
         cmpDisabled: <Button {...args} variant="white-delete" size="lg" disabled />,
+      },
+      {
+        label: 'Gray',
+        cmp: <Button {...args} variant="gray" size="sm" />,
+        cmpDisabled: <Button {...args} variant="gray" size="sm" disabled />,
       },
     ];
 
@@ -148,6 +158,22 @@ export const White: Story = {
     label: 'Muokkaa',
     onClick: fn(),
     variant: 'white',
+  },
+};
+
+export const Gray: Story = {
+  parameters: {
+    design,
+    docs: {
+      description: {
+        story: 'This is a gray button component for triggering an action.',
+      },
+    },
+  },
+  args: {
+    label: 'Muokkaa',
+    onClick: fn(),
+    variant: 'gray',
   },
 };
 

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -19,7 +19,7 @@ export interface ButtonProps {
   /** Size of the button */
   size?: 'sm' | 'lg';
   /** Button variant (primary = accent, secondary = white, tertiary = plain) */
-  variant?: 'white' | 'red-delete' | 'white-delete' | 'accent' | 'plain';
+  variant?: 'white' | 'red-delete' | 'white-delete' | 'accent' | 'plain' | 'gray';
   /** Service variant */
   serviceVariant?: ServiceVariant;
   /** Button disabled for any actions */
@@ -74,6 +74,10 @@ const getVariantClassName = (
       [`ds:bg-white ds:text-black ${focusColor} ${hoverColor} ${activeTextColor} ${focusTextColor}`]:
         variant === 'white' && !disabled,
 
+      // Gray
+      [`ds:bg-bg-gray ds:text-black ${focusColor} ${hoverColor} ${activeTextColor} ${focusTextColor}`]:
+        variant === 'gray' && !disabled,
+
       // Plain
       [`${textColor} ${hoverColor} ${focusColor} ${activeTextColor}`]: variant === 'plain' && !disabled,
       [`ds:text-inactive-gray`]: variant === 'plain' && disabled,
@@ -90,6 +94,7 @@ const getVariantClassName = (
         variant && ['red-delete', 'white', 'white-delete'].includes(variant) && disabled,
       [`ds:bg-inactive-gray ds:text-secondary-5-light-3`]:
         variant && ['accent', 'red-delete'].includes(variant) && disabled,
+      [`ds:bg-bg-gray ds:text-secondary-gray`]: variant === 'gray' && disabled,
     },
   );
 };
@@ -150,7 +155,7 @@ export const Button = ({
 
   const spanClassName = cx({
     'ds:group-hover:underline ds:group-active:no-underline ds:group-focus-visible:no-underline': !disabled,
-    'ds:py-2': size === 'sm',
+    'ds:py-3 ds:h-7': size === 'sm',
     'ds:py-4': size === 'lg' && variant !== 'plain',
   });
 

--- a/lib/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/lib/components/Button/__snapshots__/Button.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Button > renders the button with the correct size 1`] = `
   type="button"
 >
   <span
-    class="ds:group-hover:underline ds:group-active:no-underline ds:group-focus-visible:no-underline ds:py-2"
+    class="ds:group-hover:underline ds:group-active:no-underline ds:group-focus-visible:no-underline ds:py-3 ds:h-7"
   >
     Click me
   </span>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
* Fix sm button size, it was 26px but in the design it's 32px
* Add gray button variant back. There was no design for disabled state, so I took a guess.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1953

<img width="643" height="65" alt="image" src="https://github.com/user-attachments/assets/2d25bdf1-3cfa-469e-bcd1-29e456dd76d2" />

