### PR TITLE
OPHJOD-1904: Adjust spacings of the Modal

### DIFF
--- a/lib/components/Modal/Modal.tsx
+++ b/lib/components/Modal/Modal.tsx
@@ -77,15 +77,16 @@ export const Modal = ({
                 'ds:max-w-[1092px]',
                 'ds:grid-cols-1',
                 'ds:gap-6',
-                'ds:my-6',
+                'ds:sm:my-8',
+                'ds:my-5',
                 'ds:sm:grid-cols-3',
-                'ds:pl-5',
-                'ds:md:pl-9',
+                'ds:px-3',
+                'ds:md:px-9',
                 'ds:relative',
               ])}
             >
               {/* Main content */}
-              {progress && <div className="ds:absolute ds:top-0 ds:right-5">{progress}</div>}
+              {progress && <div className="ds:absolute ds:top-0 ds:right-5 ds:md:right-9">{progress}</div>}
               <div
                 className={tc([
                   heightClasses,
@@ -93,20 +94,23 @@ export const Modal = ({
                   'ds:flex',
                   'ds:flex-col',
                   'ds:gap-y-6',
-                  'ds:pr-5',
+                  'ds:pr-0 sm:ds:pr-5',
                   sidePanel || !fullWidthContent
                     ? 'ds:sm:col-span-2'
-                    : 'ds:sm:col-span-3 ds:mr-0 ds:sm:mr-5 ds:md:mr-9',
-                  progress && !sm ? 'ds:mt-6 ds:sm:mt-8' : '',
+                    : 'ds:sm:col-span-3 ds:mr-0 ds:sm:mr-5 ds:md:mr-0',
+                  progress && !sm ? 'ds:mt-7 ds:sm:mt-8' : '',
                   'ds:sm:pr-0',
+                  sidePanel && progress ? 'ds:sm:mt-8' : '',
                 ])}
               >
-                <div className={`ds:overflow-y-auto ds:p-3 ${progress ? 'ds:sm:mt-10 ds:mt-8' : ''}`}>{content}</div>
+                <div className={`ds:overflow-y-auto ds:p-0 ds:px-3 sm:ds:p-3 ${progress ? 'ds:sm:mt-0 ds:mt-5' : ''}`}>
+                  {content}
+                </div>
               </div>
               {/* Side panel */}
               {sm && sidePanel && !fullWidthContent && (
                 <div className={`ds:col-span-1 ds:flex ds:flex-col ${heightClasses}`}>
-                  <div className={`ds:mr-5 ds:sm:mr-9 ds:overflow-y-auto ${progress ? 'ds:sm:mt-8 ds:mt-6' : ''}`}>
+                  <div className={`ds:mr-5 ds:sm:mr-0 ds:overflow-y-auto ${progress ? 'ds:sm:mt-8 ds:mt-6' : ''}`}>
                     {sidePanel}
                   </div>
                 </div>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Updated the spacings in the `Modal` component to match with the updated design.

## Screenshots
Here are some example of the modals
- Gained more space for actual content.

### Mobile

#### Before

<img width="600"  alt="SCR-20250901-ighm-2" src="https://github.com/user-attachments/assets/d57820b3-4c67-45f2-a337-8533634f60e8" />

#### After

<img width="600" alt="SCR-20250901-iglj-2" src="https://github.com/user-attachments/assets/6f3c8d1a-bf0a-413f-bcb4-bbb1e03f4b0a" />

### Desktop

#### Before

<img width="800" alt="SCR-20250901-igve-2" src="https://github.com/user-attachments/assets/84ca7b82-2065-42a0-b170-93adaa5b99cf" />

#### After
<img width="800"  alt="SCR-20250901-igxz-2" src="https://github.com/user-attachments/assets/83d35a22-7583-420e-9565-c435206b1f30" />



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1904
