### PR TITLE
OPHJOD-1892: Update Accordion component to support outside control

### DIFF
--- a/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Accordion > renders accordion with open state by default 1`] = `
 >
   <button
     aria-expanded="true"
-    class="ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:group-hover:text-accent! ds:mb-2"
+    class="ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:group-hover:text-accent! ds:group ds:mb-2"
   >
     <span
       class="ds:mr-5 ds:w-full ds:text-left ds:hyphens-auto ds:text-heading-3 ds:group-hover:underline"


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Some changes that the tool design update requires:
* Update `Accordion` component to support control from outside by passing `isOpen` and `setIsOpen` props.
* Add `caretPosition` prop that allows setting the position to `center` or `top`. `center` is the default like it previously was.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1892
