### PR TITLE
OPHJOD-2004: Add className prop for Accordion

### DIFF
--- a/lib/components/Accordion/Accordion.stories.tsx
+++ b/lib/components/Accordion/Accordion.stories.tsx
@@ -105,3 +105,22 @@ export const WithAsync: Story = {
     fetchData: async () => new Promise((resolve) => setTimeout(resolve, 5000)),
   },
 };
+
+export const GrayClosedByDefault: Story = {
+  decorators,
+  parameters: {
+    ...parameters,
+    docs: {
+      description: {
+        story: 'Accordion that is closed by default and is gray variant',
+      },
+    },
+  },
+  args: {
+    title: 'Title',
+    children: <div className="ds:bg-bg-gray-2 ds:px-5 ds:pb-3">{'Content'}</div>,
+    lang: 'en',
+    initialState: false,
+    className: 'ds:bg-bg-gray-2 ds:p-3',
+  },
+};

--- a/lib/components/Accordion/Accordion.tsx
+++ b/lib/components/Accordion/Accordion.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { cx } from '../../cva';
 import { JodCaretDown, JodCaretUp } from '../../icons';
+import { tidyClasses } from '../../utils';
 import { Spinner } from '../Spinner/Spinner';
 
 type TitleProps =
@@ -35,6 +36,8 @@ type AccordionProps = {
   fetchData?: () => Promise<void>;
   /** Test id for querying in tests */
   dataTestId?: string;
+  /**  className for wrapper */
+  className?: string;
 } & TitleProps;
 
 const Caret = ({ isOpen }: { isOpen: boolean }) => (
@@ -55,6 +58,7 @@ export const Accordion = ({
   dataTestId,
   isOpen: controlledIsOpen,
   setIsOpen: controlledSetIsOpen,
+  className,
 }: AccordionProps) => {
   const [internalIsOpen, setInternalIsOpen] = React.useState(initialState);
   const isControlled = controlledIsOpen !== undefined;
@@ -98,7 +102,7 @@ export const Accordion = ({
   }, [fetchData, fetchStatus, isOpen, setIsOpen]);
 
   return (
-    <>
+    <div className={tidyClasses(className || '')}>
       {isTitleValidElement ? (
         <div className={wrapperClassnames}>
           {title}
@@ -132,6 +136,6 @@ export const Accordion = ({
         </div>
       )}
       {isOpen && (!fetchData || fetchStatus === 'done') && children}
-    </>
+    </div>
   );
 };

--- a/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -2,37 +2,44 @@
 
 exports[`Accordion > renders accordion with open state by default 1`] = `
 <div
-  class="ds:group"
+  class=""
 >
-  <button
-    aria-expanded="true"
-    class="ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:group-hover:text-accent! ds:group ds:mb-2"
+  <div
+    class="ds:group"
   >
-    <span
-      class="ds:mr-5 ds:w-full ds:text-left ds:hyphens-auto ds:text-heading-3 ds:group-hover:underline"
-      lang="en"
+    <button
+      aria-expanded="true"
+      class="ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:group-hover:text-accent! ds:group ds:mb-2"
     >
-      Accordion Title
-    </span>
-    <span
-      aria-hidden="true"
-      class="ds:text-primary-gray ds:group-hover:text-accent!"
-    >
-      <svg
-        fill="currentColor"
-        height="24"
-        stroke="currentColor"
-        stroke-width="0"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="ds:mr-5 ds:w-full ds:text-left ds:hyphens-auto ds:text-heading-3 ds:group-hover:underline"
+        lang="en"
       >
-        <path
-          d="M12 11.0964L7.4 15.6964L6 14.2964L12 8.29639L18 14.2964L16.6 15.6964L12 11.0964Z"
+        Accordion Title
+      </span>
+      <span
+        aria-hidden="true"
+        class="ds:text-primary-gray ds:group-hover:text-accent!"
+      >
+        <svg
           fill="currentColor"
-        />
-      </svg>
-    </span>
-  </button>
+          height="24"
+          stroke="currentColor"
+          stroke-width="0"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 11.0964L7.4 15.6964L6 14.2964L12 8.29639L18 14.2964L16.6 15.6964L12 11.0964Z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+  <div>
+    Default content
+  </div>
 </div>
 `;


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Add `className` prop that goes to the wrapper
- Fix the component elements to be inside same element

## Screenshot
Example of using `className` prop with the existing `initialState` prop set to `false`
<img width="600" height="59" alt="image" src="https://github.com/user-attachments/assets/2711c146-634a-461b-a5dd-8df60f4c92fb" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2004
