### PR TITLE
OPHJOD-2207: Update Note's feedback variant and fix layout for mobile

### DIFF
--- a/lib/components/Note/Note.stories.tsx
+++ b/lib/components/Note/Note.stories.tsx
@@ -3,6 +3,7 @@ import { fn } from 'storybook/test';
 import type { TitledMeta } from '../../utils';
 
 import { Note, NoteStack, NoteStackProvider, useNoteStack } from '.';
+import { JodOpenInNew } from '../../icons';
 import { Button } from '../Button/Button';
 import { NoteProps } from './Note';
 
@@ -56,6 +57,7 @@ export const ConfirmationNote: Story = {
     title,
     description,
     readMoreComponent,
+    variant: 'success',
     onCloseClick: fn(),
   },
 };
@@ -77,6 +79,7 @@ export const LongTitleText: Story = {
     title: 'Lorem ipsum dolor est nonummy noblem ester!',
     description,
     readMoreComponent,
+    variant: 'success',
     onCloseClick: fn(),
   },
 };
@@ -171,14 +174,18 @@ export const feedback: Story = {
     },
     docs: {
       description: {
-        story: 'This is a warning note component for displaying a text.',
+        story: 'This is a feedback note component for displaying a text.',
       },
     },
   },
   args: {
-    title,
-    description,
+    title: 'Kokeile palvelua',
+    description: 'Kerro mielipiteesi ja auta meitä kehittämään palvelua.',
     variant: 'feedback',
+    readMoreComponent: (
+      <Button variant="white" label="Siirry kyselyyn" icon={<JodOpenInNew />} iconSide="right" size="sm" />
+    ),
+    onCloseClick: fn(),
   },
 };
 

--- a/lib/components/Note/Note.tsx
+++ b/lib/components/Note/Note.tsx
@@ -12,7 +12,7 @@ export interface NoteProps {
   variant?: 'success' | 'warning' | 'error' | 'feedback';
   /** Callback fired on tap/click of the close button */
   onCloseClick?: () => void;
-  /** Component inside the button container if variant is success */
+  /** Call to action (CTA) component */
   readMoreComponent?: React.ReactNode;
   /** If true, the note will always be visible */
   permanent?: boolean;
@@ -33,7 +33,6 @@ export const Note = ({
   dataTestId,
 }: NoteProps) => {
   const { sm } = useMediaQueries();
-  const hasReadMore = variant === 'success' && readMoreComponent;
 
   return (
     <div
@@ -46,21 +45,21 @@ export const Note = ({
         'ds:bg-success ds:text-primary-gray': variant === 'success',
         'ds:bg-warning ds:text-primary-gray': variant === 'warning',
         'ds:bg-alert ds:text-white': variant === 'error',
-        'ds:bg-secondary-gray ds:text-white': variant === 'feedback',
-        'ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8': !collapsed,
+        'ds:bg-secondary-3 ds:text-primary-gray': variant === 'feedback',
+        'ds:px-5 ds:pt-4 ds:pb-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 sm:ds:h-8': !collapsed,
         'ds:h-0': collapsed,
       })}
       data-testid={dataTestId}
     >
-      <div className="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6">
+      <div className="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-3 ds:sm:gap-6">
         <div className="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6">
           <div className="ds:text-heading-4 ds:text-pretty">{title}</div>
           <div className="ds:text-body-md ds:font-arial ds:text-pretty">{description}</div>
-          {hasReadMore && !sm && <span className="ds:mt-3">{readMoreComponent}</span>}
+          {readMoreComponent && !sm && <span className="ds:mt-3">{readMoreComponent}</span>}
         </div>
 
         <div className="ds:flex ds:sm:items-center ds:gap-6 ds:not-sm:self-start">
-          {hasReadMore && sm && readMoreComponent}
+          {sm && readMoreComponent}
           {onCloseClick && !permanent && (
             <button
               className="ds:cursor-pointer ds:flex"

--- a/lib/components/Note/__snapshots__/Note.test.tsx.snap
+++ b/lib/components/Note/__snapshots__/Note.test.tsx.snap
@@ -4,12 +4,12 @@ exports[`Note component > renders with close button 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
+  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:pt-4 ds:pb-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 sm:ds:h-8"
   data-testid="note3"
   role="alert"
 >
   <div
-    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6"
+    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-3 ds:sm:gap-6"
   >
     <div
       class="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6"
@@ -58,11 +58,11 @@ exports[`Note component > renders with error variant 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-alert ds:text-white ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
+  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-alert ds:text-white ds:px-5 ds:pt-4 ds:pb-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 sm:ds:h-8"
   role="alert"
 >
   <div
-    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6"
+    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-3 ds:sm:gap-6"
   >
     <div
       class="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6"
@@ -89,12 +89,12 @@ exports[`Note component > renders with read more component 1`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:py-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 ds:h-8"
+  class="ds:transition-[height] ds:duration-100 ds:overflow-clip ds:bg-success ds:text-primary-gray ds:px-5 ds:pt-4 ds:pb-3 ds:sm:py-2 ds:md:py-1 ds:lg:py-0 sm:ds:h-8"
   data-testid="note2"
   role="alert"
 >
   <div
-    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-6"
+    class="ds:mx-auto ds:flex ds:min-h-8 ds:items-center ds:justify-center ds:gap-3 ds:sm:gap-6"
   >
     <div
       class="ds:flex ds:flex-col ds:sm:flex-row ds:flex-wrap ds:sm:items-center ds:sm:gap-x-6"


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Update `feedback`variant style
- Fix to work on mobile as in the design

## Notes

`readMoreComponent` prop might be better renamed to something like `callToActionComponent`. But did not want to make breaking change from that.

## Screenshots

### Mobile 
<img width="300" alt="SCR-20250922-lrbr" src="https://github.com/user-attachments/assets/1cebb208-e1d0-4bc5-b19a-bd18d03587e7" />

### Desktop
<img width="600" alt="SCR-20250922-lree" src="https://github.com/user-attachments/assets/c4411a3e-7689-416e-b91b-2de0da342492" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2207
