### PR TITLE
OPHJOD-2210: Fix sm button variant with long label

### DIFF
--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -161,7 +161,7 @@ export const Button = ({
 
   const spanClassName = cx({
     'ds:group-hover:underline ds:group-active:no-underline ds:group-focus-visible:no-underline': !disabled,
-    'ds:py-3 ds:h-7': size === 'sm',
+    'ds:py-3 ds:min-h-7': size === 'sm',
     'ds:py-4': size === 'lg' && variant !== 'plain',
   });
 

--- a/lib/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/lib/components/Button/__snapshots__/Button.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Button > renders the button with the correct size 1`] = `
   type="button"
 >
   <span
-    class="ds:group-hover:underline ds:group-active:no-underline ds:group-focus-visible:no-underline ds:py-3 ds:h-7"
+    class="ds:group-hover:underline ds:group-active:no-underline ds:group-focus-visible:no-underline ds:py-3 ds:min-h-7"
   >
     Click me
   </span>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
* Fix `sm` button variant overflowing when the label is too long

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2210

**Short label**
<img width="573" height="808" alt="image" src="https://github.com/user-attachments/assets/3612ade4-70d3-4e5f-82e1-ba81f7a2200a" />


**Long label**

<img width="896" height="576" alt="image" src="https://github.com/user-attachments/assets/e57d9e7d-7fc0-4595-9027-e7c826eb1749" />
