### PR TITLE
OPHJOD-1999: Make modal footer optional

### DIFF
--- a/lib/components/Modal/Modal.tsx
+++ b/lib/components/Modal/Modal.tsx
@@ -8,7 +8,7 @@ export interface ModalProps {
   open: boolean;
   onClose?: () => void;
   content: React.ReactNode;
-  footer: React.ReactNode;
+  footer?: React.ReactNode;
   progress?: React.ReactNode;
   /** Slot is not used on mobile. */
   sidePanel?: React.ReactNode;
@@ -148,12 +148,14 @@ export const Modal = ({
               )}
             </div>
             {/* Footer, button area */}
-            <div
-              className="ds:flex ds:bg-bg-gray-2 ds:overflow-x-auto ds:overflow-y-hidden ds:justify-between ds:py-4 ds:sm:py-5 ds:px-4 ds:sm:px-9 ds:z-50"
-              data-testid={dataTestId ? `${dataTestId}-footer` : undefined}
-            >
-              {footer}
-            </div>
+            {footer && (
+              <div
+                className="ds:flex ds:bg-bg-gray-2 ds:overflow-x-auto ds:overflow-y-hidden ds:justify-between ds:py-4 ds:sm:py-5 ds:px-4 ds:sm:px-9 ds:z-50"
+                data-testid={dataTestId ? `${dataTestId}-footer` : undefined}
+              >
+                {footer}
+              </div>
+            )}
           </DialogPanel>
         </div>
       </div>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
* Make modal `footer` prop optional and don't render the footer section if it's not defined
  * This type of modal is needed in yksilö UI tool filters

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1999

<img width="451" height="867" alt="image" src="https://github.com/user-attachments/assets/cdacd840-64f5-4b6f-8fb6-d006880bf683" />
