### PR TITLE
OPHJOD-1809: Fix PageNavigation item highlight width

### DIFF
--- a/lib/components/NavigationMenu/components/MenuList.tsx
+++ b/lib/components/NavigationMenu/components/MenuList.tsx
@@ -127,7 +127,6 @@ const MenuListItem = ({
                 !selected ? 'ds:hover:bg-bg-gray' : '',
                 selected ? getSelectedClasses() : '',
                 getPressedBgColorClassForService(serviceVariant),
-                !childItems || childItems.length === 0 ? 'ds:max-w-[calc(100%-44px)]' : '',
               ])}
             >
               {icon}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
In `PageNavigation`, the list items selected background now take the whole available width, just like the focus outline

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-1809

<img width="365" height="372" alt="image" src="https://github.com/user-attachments/assets/6a0236ad-a2b0-44a9-b0c6-0375fcb575bb" />

<img width="371" height="363" alt="image" src="https://github.com/user-attachments/assets/088cee2a-8ff2-4606-9340-36d9e5c6d3f2" />


