### PR TITLE
OPHJOD-2241: Update default colors for portal variant and remove extra separator if menu section is not defined

### DIFF
--- a/lib/components/NavigationMenu/NavigationMenu.stories.tsx
+++ b/lib/components/NavigationMenu/NavigationMenu.stories.tsx
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof meta>;
 const parameters = {
   design: {
     type: 'figma',
-    url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=10543-34956',
+    url: 'https://www.figma.com/design/6M2LrpSCcB0thlFDaQAI2J/cx_jod_client?node-id=16193-157159',
   },
 };
 
@@ -175,6 +175,25 @@ const languageSelectionItems = [
   },
 ];
 
+const baseProps: NavigationMenuProps = {
+  portalLinkLabel: 'Osaamispolkuportaali',
+  PortalLinkComponent: ({ children, className }: LinkComponent) => (
+    <a href="/#" className={className}>
+      {children}
+    </a>
+  ),
+  onClose: fn(),
+  open: true,
+  menuSection: menuSection,
+  openSubMenuLabel: 'Avaa alivalikko',
+  ariaCloseMenu: 'Sulje valikko',
+  externalLinkSections: externalLinkSections,
+  languageSelectionItems: languageSelectionItems,
+  languageSelectionTitle: 'Käyttökieli',
+  selectedLanguage: 'fi',
+  serviceVariant: 'yksilo',
+};
+
 const DefaultRender = (props: NavigationMenuProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
   return (
@@ -196,21 +215,22 @@ export const Default: Story = {
   },
   render: DefaultRender,
   args: {
-    portalLinkLabel: 'Osaamispolkuportaali',
-    PortalLinkComponent: ({ children, className }: LinkComponent) => (
-      <a href="/#" className={className}>
-        {children}
-      </a>
-    ),
-    onClose: fn(),
-    open: true,
-    menuSection: menuSection,
-    openSubMenuLabel: 'Avaa alivalikko',
-    ariaCloseMenu: 'Sulje valikko',
-    externalLinkSections: externalLinkSections,
-    languageSelectionItems: languageSelectionItems,
-    languageSelectionTitle: 'Käyttökieli',
-    selectedLanguage: 'fi',
-    serviceVariant: 'yksilo',
+    ...baseProps,
+  },
+};
+
+export const WithoutMenuSection: Story = {
+  parameters: {
+    ...parameters,
+    docs: {
+      description: {
+        story: 'NavigationMenu component without the the main menu section.',
+      },
+    },
+  },
+  render: DefaultRender,
+  args: {
+    ...baseProps,
+    menuSection: undefined,
   },
 };

--- a/lib/components/NavigationMenu/NavigationMenu.tsx
+++ b/lib/components/NavigationMenu/NavigationMenu.tsx
@@ -40,7 +40,7 @@ export interface NavigationMenuProps {
   /** Link component to bring user to front page */
   PortalLinkComponent: React.ComponentType<LinkComponent>;
   /** Menu items. Items can have children */
-  menuSection: MenuSection;
+  menuSection?: MenuSection;
   /** Label for button to open submenu of menu item */
   openSubMenuLabel: string;
   /** External link sections */
@@ -108,7 +108,7 @@ export const NavigationMenu = ({
             {portalLinkLabel && PortalLinkComponent ? (
               <>
                 <PortalLink label={portalLinkLabel} icon={portalIcon} component={PortalLinkComponent} />
-                <MenuSeparator />
+                {menuSection && <MenuSeparator />}
               </>
             ) : null}
             <MenuList

--- a/lib/components/NavigationMenu/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/components/NavigationMenu/__snapshots__/NavigationMenu.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`NavigationMenu > renders navigation menu with default state 1`] = `
         </div>
       </div>
       <div
-        class="ds:border-l-8 ds:border-secondary-3-dark"
+        class="ds:border-l-8 ds:border-secondary-gray"
       >
         <a
           class="ds:flex ds:flex-1 ds:gap-3 ds:p-3 ds:ml-3 ds:mr-9 ds:cursor-pointer ds:group ds:rounded ds:active:text-white ds:text-black ds:hover:bg-bg-gray ds:active:bg-secondary-1-dark-2 ds:focus-visible:outline-secondary-1-dark"

--- a/lib/components/NavigationMenu/components/MenuList.tsx
+++ b/lib/components/NavigationMenu/components/MenuList.tsx
@@ -189,7 +189,7 @@ export interface MenuListProps {
   /** How should the active menu item be indicated */
   activeIndicator?: 'dot' | 'bg';
   /** Menu data */
-  menuSection: MenuSection;
+  menuSection?: MenuSection;
   /** Reference to the menu element */
   menuRef?: React.RefObject<HTMLUListElement | null>;
   /** Whether the menu is nested */
@@ -227,34 +227,40 @@ export const MenuList = ({
     : cx('ds:border-l-8', {
         'ds:border-secondary-1-dark': variant === 'yksilo',
         'ds:border-secondary-2-dark': variant === 'ohjaaja',
-        'ds:border-secondary-3-dark': variant === 'palveluportaali',
+        'ds:border-secondary-gray': variant === 'palveluportaali',
         'ds:border-secondary-4-dark': variant === 'tietopalvelu',
       });
 
   return (
-    <div data-testid={dataTestId}>
-      {menuSection.title ? <span className="ds:text-body-sm ds:mb-5 ds:mt-2 ds:flex">{menuSection.title}</span> : null}
-      <ul
-        className={tc(['ds:gap-2', 'ds:flex', 'ds:flex-col', isNested ? 'ds:ml-6' : borderClassname])}
-        ref={menuRef}
-        data-testid={dataTestId ? `${dataTestId}-list` : undefined}
-      >
-        {menuSection.linkItems.map((item) => (
-          <MenuListItem
-            key={item.label}
-            activeIndicator={activeIndicator}
-            label={item.label}
-            selected={item.selected}
-            childItems={item.childItems}
-            icon={item.icon}
-            LinkComponent={item.LinkComponent}
-            openSubMenuLabel={openSubMenuLabel}
-            className={itemClassname}
-            collapsed={collapsed}
-            data-testid={dataTestId ? `${dataTestId}-item-${item.label.replace(/\s+/g, '-').toLowerCase()}` : undefined}
-          />
-        ))}
-      </ul>
-    </div>
+    menuSection && (
+      <div data-testid={dataTestId}>
+        {menuSection.title ? (
+          <span className="ds:text-body-sm ds:mb-5 ds:mt-2 ds:flex">{menuSection.title}</span>
+        ) : null}
+        <ul
+          className={tc(['ds:gap-2', 'ds:flex', 'ds:flex-col', isNested ? 'ds:ml-6' : borderClassname])}
+          ref={menuRef}
+          data-testid={dataTestId ? `${dataTestId}-list` : undefined}
+        >
+          {menuSection.linkItems.map((item) => (
+            <MenuListItem
+              key={item.label}
+              activeIndicator={activeIndicator}
+              label={item.label}
+              selected={item.selected}
+              childItems={item.childItems}
+              icon={item.icon}
+              LinkComponent={item.LinkComponent}
+              openSubMenuLabel={openSubMenuLabel}
+              className={itemClassname}
+              collapsed={collapsed}
+              data-testid={
+                dataTestId ? `${dataTestId}-item-${item.label.replace(/\s+/g, '-').toLowerCase()}` : undefined
+              }
+            />
+          ))}
+        </ul>
+      </div>
+    )
   );
 };

--- a/lib/components/NavigationMenu/components/PortalLink.tsx
+++ b/lib/components/NavigationMenu/components/PortalLink.tsx
@@ -20,7 +20,7 @@ export const PortalLink = ({
   const variant = useServiceVariant();
 
   return (
-    <div className="ds:border-l-8 ds:border-secondary-3-dark">
+    <div className="ds:border-l-8 ds:border-secondary-gray">
       <Component
         className={tidyClasses([
           'ds:flex',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -39,7 +39,7 @@ export const getAccentBgClassForService = (variant: ServiceVariant) =>
   cx({
     'ds:bg-secondary-1-dark': variant === 'yksilo',
     'ds:bg-secondary-2-dark': variant === 'ohjaaja',
-    'ds:bg-secondary-3-dark': variant === 'palveluportaali',
+    'ds:bg-secondary-gray': variant === 'palveluportaali',
     'ds:bg-secondary-4-dark': variant === 'tietopalvelu',
   });
 
@@ -47,7 +47,7 @@ export const getPressedBgColorClassForService = (variant: ServiceVariant) =>
   cx({
     'ds:active:bg-secondary-1-dark-2': variant === 'yksilo',
     'ds:active:bg-secondary-2-dark-2': variant === 'ohjaaja',
-    'ds:active:bg-secondary-3-dark-2': variant === 'palveluportaali',
+    'ds:active:bg-primary-gray': variant === 'palveluportaali',
     'ds:active:bg-secondary-4-dark-2': variant === 'tietopalvelu',
   });
 
@@ -55,7 +55,7 @@ export const getTextColorClassForService = (variant: ServiceVariant) =>
   cx({
     'ds:text-secondary-1-dark': variant === 'yksilo',
     'ds:text-secondary-2-dark': variant === 'ohjaaja',
-    'ds:text-secondary-3-dark': variant === 'palveluportaali',
+    'ds:text-secondary-gray': variant === 'palveluportaali',
     'ds:text-secondary-4-dark': variant === 'tietopalvelu',
   });
 
@@ -63,6 +63,6 @@ export const getFocusOutlineClassForService = (variant: ServiceVariant) =>
   cx({
     'ds:focus-visible:outline-secondary-1-dark': variant === 'yksilo',
     'ds:focus-visible:outline-secondary-2-dark': variant === 'ohjaaja',
-    'ds:focus-visible:outline-secondary-3-dark': variant === 'palveluportaali',
+    'ds:focus-visible:outline-secondary-gray': variant === 'palveluportaali',
     'ds:focus-visible:outline-secondary-4-dark': variant === 'tietopalvelu',
   });


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

* Updated the "palveluportaali" variant colorings, it's now gray instead of yellowish.
* Make menuSection optional and don't display a separator if menuSection is not defined (OPHJOD-1942)

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2241
https://jira.eduuni.fi/browse/OPHJOD-1942

<img width="373" height="884" alt="image" src="https://github.com/user-attachments/assets/5b0cca77-a49f-432b-b0db-2c8fad86842d" />

Without menu section:
<img width="367" height="504" alt="image" src="https://github.com/user-attachments/assets/7a4ab067-1b75-4261-ab2d-a1958082d6fa" />



