### PR TITLE
OPHJOD-2121: Add tooltip support to Tag

### DIFF
--- a/lib/components/Tag/Tag.stories.tsx
+++ b/lib/components/Tag/Tag.stories.tsx
@@ -76,3 +76,12 @@ export const Multiline: Story = {
     variant: 'presentation',
   },
 };
+
+export const Tooltip: Story = {
+  args: {
+    label: 'This tag has a tooltip',
+    tooltip: 'This is the tooltip text',
+    sourceType: 'kiinnostus',
+    variant: 'presentation',
+  },
+};

--- a/lib/components/Tag/Tag.tsx
+++ b/lib/components/Tag/Tag.tsx
@@ -1,9 +1,10 @@
 import { cx } from 'cva';
 import { JodAdd, JodClose } from '../../icons';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../main';
 
 interface BaseTagProps {
   label: string;
-  title?: string;
+  tooltip?: string;
   variant?: 'selectable' | 'added' | 'presentation';
   sourceType?: 'tyopaikka' | 'koulutus' | 'vapaa-ajan-toiminto' | 'kiinnostus' | 'jotain-muuta' | 'rajoitus';
   dataTestId?: string;
@@ -38,28 +39,39 @@ const containerClassNames = (sourceType: TagProps['sourceType'], variant: TagPro
 /** Tags allow users to categorize content. They can represent keywords or people, and are grouped to describe an item or a search request. */
 export const Tag = ({
   label,
-  title,
+  tooltip,
   onClick,
   variant = 'selectable',
   sourceType = 'jotain-muuta',
   dataTestId,
 }: TagProps) => {
-  return variant === 'presentation' ? (
-    <div className={containerClassNames(sourceType, variant)} title={title} data-testid={dataTestId}>
-      <span className="ds:hyphens-auto ds:text-primary-gray">{label}</span>
-    </div>
-  ) : (
-    <button
-      type="button"
-      className={containerClassNames(sourceType, variant)}
-      onClick={onClick}
-      title={title}
-      data-testid={dataTestId}
-    >
-      <span className="ds:hyphens-auto ds:text-primary-gray ds:group-hover:underline">{label}</span>
-      <span className="ds:pl-3 ds:text-button-md ds:text-primary-gray" aria-hidden>
-        {variant === 'selectable' ? <JodAdd size={16} /> : <JodClose size={16} />}
-      </span>
-    </button>
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {variant === 'presentation' ? (
+          <div
+            className={containerClassNames(sourceType, variant)}
+            data-testid={dataTestId}
+            role={tooltip ? 'button' : undefined}
+            tabIndex={tooltip ? 0 : undefined}
+          >
+            <span className="ds:hyphens-auto ds:text-primary-gray">{label}</span>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={containerClassNames(sourceType, variant)}
+            onClick={onClick}
+            data-testid={dataTestId}
+          >
+            <span className="ds:hyphens-auto ds:text-primary-gray ds:group-hover:underline">{label}</span>
+            <span className="ds:pl-3 ds:text-button-md ds:text-primary-gray" aria-hidden>
+              {variant === 'selectable' ? <JodAdd size={16} /> : <JodClose size={16} />}
+            </span>
+          </button>
+        )}
+      </TooltipTrigger>
+      {tooltip && <TooltipContent>{tooltip}</TooltipContent>}
+    </Tooltip>
   );
 };

--- a/lib/components/Tooltip/TooltipContent.tsx
+++ b/lib/components/Tooltip/TooltipContent.tsx
@@ -30,6 +30,7 @@ export const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentPro
             'ds:text-body-xs',
             'ds:font-arial',
             'ds:text-white',
+            'ds:z-50',
           ])}
           ref={ref}
           style={{


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Add tooltip support to Tag

<img width="244" height="193" alt="image" src="https://github.com/user-attachments/assets/3c6b25b4-b323-45c0-9857-52c0d89ed1ed" />

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2121
