### PR TITLE
OPHJOD-2059: Refactor Accordion component

### DIFF
--- a/lib/components/Accordion/Accordion.stories.tsx
+++ b/lib/components/Accordion/Accordion.stories.tsx
@@ -41,7 +41,6 @@ export const Default: Story = {
   args: {
     title: 'Title',
     children: 'Content',
-    lang: 'en',
   },
 };
 
@@ -62,9 +61,8 @@ export const TitleComponent: Story = {
   },
   args: {
     title: <div className="ds:text-heading-1 ds:font-arial ds:text-alert ds:italic ds:tracking-widest">Title</div>,
-    titleText: 'Title',
+    ariaLabel: 'Title',
     children: 'Content',
-    lang: 'en',
   },
 };
 
@@ -82,7 +80,6 @@ export const WithUnderline: Story = {
     title: 'Title',
     children: 'Content',
     underline: true,
-    lang: 'en',
   },
 };
 
@@ -100,7 +97,6 @@ export const WithAsync: Story = {
     title: 'Title',
     children: 'Content',
     underline: true,
-    lang: 'en',
     initialState: false,
     fetchData: async () => new Promise((resolve) => setTimeout(resolve, 5000)),
   },
@@ -119,7 +115,6 @@ export const GrayClosedByDefault: Story = {
   args: {
     title: 'Title',
     children: <div className="ds:bg-bg-gray-2 ds:px-5 ds:pb-3">{'Content'}</div>,
-    lang: 'en',
     initialState: false,
     className: 'ds:bg-bg-gray-2 ds:p-3',
   },

--- a/lib/components/Accordion/Accordion.test.tsx
+++ b/lib/components/Accordion/Accordion.test.tsx
@@ -1,16 +1,14 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-
 import { Accordion } from './Accordion';
 
 describe('Accordion', () => {
   const title = 'Accordion Title';
-  const lang = 'en';
 
   it('renders accordion with open state by default', () => {
     const { container } = render(
-      <Accordion title={title} lang={lang}>
+      <Accordion title={title}>
         <div>Default content</div>
       </Accordion>,
     );
@@ -27,7 +25,7 @@ describe('Accordion', () => {
 
   it('closes accordion when expand button is clicked', () => {
     render(
-      <Accordion title={title} lang={lang}>
+      <Accordion title={title}>
         <div>Content to be gone</div>
       </Accordion>,
     );
@@ -38,75 +36,75 @@ describe('Accordion', () => {
     const accordionContent = screen.queryByText('Content to be gone');
     expect(accordionContent).not.toBeInTheDocument();
   });
-});
 
-it('calls fetchData only once when opening and shows spinner while loading', async () => {
-  const fetchData = vi.fn(() => new Promise((resolve) => setTimeout(resolve, 50)));
+  it('calls fetchData only once when opening and shows spinner while loading', async () => {
+    const fetchData = vi.fn(() => new Promise((resolve) => setTimeout(resolve, 50)));
 
-  render(
-    <Accordion title="With fetch" lang="en" fetchData={fetchData as () => Promise<void>}>
-      <div>Fetched content</div>
-    </Accordion>,
-  );
+    render(
+      <Accordion title="With fetch" fetchData={fetchData as () => Promise<void>}>
+        <div>Fetched content</div>
+      </Accordion>,
+    );
 
-  // Accordion is open by default, so close it first
-  const expandButton = screen.getByRole('button');
-  fireEvent.click(expandButton);
+    // Accordion is open by default, so close it first
+    const expandButton = screen.getByRole('button');
+    fireEvent.click(expandButton);
 
-  // Now open it, triggering fetchData
-  fireEvent.click(expandButton);
+    // Now open it, triggering fetchData
+    fireEvent.click(expandButton);
 
-  expect(fetchData).toHaveBeenCalledTimes(1);
-  expect(screen.getByRole('alert')).toBeInTheDocument(); // Spinner
+    expect(fetchData).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('alert')).toBeInTheDocument(); // Spinner
 
-  // Content should not be visible while loading
-  expect(screen.queryByText('Fetched content')).not.toBeInTheDocument();
+    // Content should not be visible while loading
+    expect(screen.queryByText('Fetched content')).not.toBeInTheDocument();
 
-  // Wait for fetchData to resolve and spinner to disappear
-  await screen.findByText('Fetched content');
-  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    // Wait for fetchData to resolve and spinner to disappear
+    await screen.findByText('Fetched content');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
-  // Close and reopen: fetchData should not be called again
-  fireEvent.click(expandButton); // close
-  fireEvent.click(expandButton); // open
-  expect(fetchData).toHaveBeenCalledTimes(1);
-});
+    // Close and reopen: fetchData should not be called again
+    fireEvent.click(expandButton); // close
+    fireEvent.click(expandButton); // open
+    expect(fetchData).toHaveBeenCalledTimes(1);
+  });
 
-it('renders children only after fetchData resolves and accordion is open', async () => {
-  let resolveFetch: () => void;
-  const fetchData = vi.fn(
-    () =>
-      new Promise<void>((resolve) => {
-        resolveFetch = resolve;
-      }),
-  );
-  render(
-    <Accordion title="Async" lang="en" fetchData={fetchData}>
-      <div>Async content</div>
-    </Accordion>,
-  );
+  it('renders children only after fetchData resolves and accordion is open', async () => {
+    let resolveFetch: () => void;
+    const fetchData = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    render(
+      <Accordion title="Async" fetchData={fetchData}>
+        <div>Async content</div>
+      </Accordion>,
+    );
 
-  // Close and open to trigger fetchData
-  const expandButton = screen.getByRole('button');
-  fireEvent.click(expandButton); // close
-  fireEvent.click(expandButton); // open
+    // Close and open to trigger fetchData
+    const expandButton = screen.getByRole('button');
+    fireEvent.click(expandButton); // close
+    fireEvent.click(expandButton); // open
 
-  // Spinner should be visible, content should not
-  expect(screen.getByRole('alert')).toBeInTheDocument();
-  expect(screen.queryByText('Async content')).not.toBeInTheDocument();
+    // Spinner should be visible, content should not
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByText('Async content')).not.toBeInTheDocument();
 
-  // Resolve fetchData
-  resolveFetch!();
-  // Wait for content to appear
-  await screen.findByText('Async content');
-  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-});
+    // Resolve fetchData
+    resolveFetch!();
+    // Wait for content to appear
+    await screen.findByText('Async content');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
 
-it('emits data-testid on the toggle button when dataTestId is provided', () => {
-  render(
-    <Accordion title="ID Title" titleText="Toggle" lang="fi" dataTestId="acc">
-      <div>Child</div>
-    </Accordion>,
-  );
-  expect(screen.getByTestId('acc')).toBeInTheDocument();
+  it('emits data-testid on the toggle button when dataTestId is provided', () => {
+    render(
+      <Accordion title="ID Title" dataTestId="acc">
+        <div>Child</div>
+      </Accordion>,
+    );
+    expect(screen.getByTestId('acc')).toBeInTheDocument();
+  });
 });

--- a/lib/components/Accordion/Accordion.tsx
+++ b/lib/components/Accordion/Accordion.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { cx } from '../../cva';
 import { JodCaretDown, JodCaretUp } from '../../icons';
-import { tidyClasses } from '../../utils';
 import { Spinner } from '../Spinner/Spinner';
 
 type TitleProps =
   | {
       title: React.ReactNode;
-      /** If the title is a component, titleText should be provided for a11y */
-      titleText: string;
+      /** If the title is a component, ariaLabel should be provided for a11y */
+      ariaLabel: string;
     }
   | {
       title: string;
-      titleText?: never;
+      ariaLabel?: never;
     };
 
 type AccordionProps = {
@@ -20,13 +19,11 @@ type AccordionProps = {
   title: React.ReactNode | string;
   /** Accordion contents */
   children: React.ReactNode;
-  /** Language code for the accordion */
-  lang: string;
   /** Show underline on the title */
   underline?: boolean;
   /** The initial open state of the accordion */
   initialState?: boolean;
-  /** The position of the caret icon */
+  /** The vertical position of the caret icon */
   caretPosition?: 'top' | 'center';
   /** Is the accordion open (controlled mode) */
   isOpen?: boolean;
@@ -36,42 +33,33 @@ type AccordionProps = {
   fetchData?: () => Promise<void>;
   /** Test id for querying in tests */
   dataTestId?: string;
-  /**  className for wrapper */
+  /** Classnames for wrapper */
   className?: string;
 } & TitleProps;
 
 const Caret = ({ isOpen }: { isOpen: boolean }) => (
   <span className="ds:text-primary-gray ds:group-hover:text-accent!" aria-hidden>
-    {isOpen ? <JodCaretUp size={24} /> : <JodCaretDown size={24} />}
+    {isOpen ? <JodCaretUp /> : <JodCaretDown />}
   </span>
 );
 
 export const Accordion = ({
   title,
-  titleText,
+  ariaLabel,
   children,
   caretPosition = 'center',
-  lang,
   underline,
   initialState = true,
   fetchData,
   dataTestId,
   isOpen: controlledIsOpen,
   setIsOpen: controlledSetIsOpen,
-  className,
+  className = '',
 }: AccordionProps) => {
   const [internalIsOpen, setInternalIsOpen] = React.useState(initialState);
   const isControlled = controlledIsOpen !== undefined;
   const isOpen = isControlled ? controlledIsOpen : internalIsOpen;
   const setIsOpen = isControlled && controlledSetIsOpen ? controlledSetIsOpen : setInternalIsOpen;
-  const isTitleValidElement = React.isValidElement(title);
-  const wrapperClassnames = cx(
-    'ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:group-hover:text-accent! ds:group',
-    {
-      'ds:border-b ds:border-border-gray': underline,
-      'ds:mb-2': isOpen,
-    },
-  );
 
   // Reset the state when the children change
   React.useEffect(() => {
@@ -102,39 +90,29 @@ export const Accordion = ({
   }, [fetchData, fetchStatus, isOpen, setIsOpen]);
 
   return (
-    <div className={tidyClasses(className || '')}>
-      {isTitleValidElement ? (
-        <div className={wrapperClassnames}>
-          {title}
-          <button
-            aria-label={titleText}
-            aria-expanded={isOpen}
-            onClick={() => void toggleOpen()}
-            style={{ alignSelf: caretPosition === 'top' ? 'flex-start' : 'center' }}
-            className="ds:cursor-pointer ds:flex"
-            data-testid={dataTestId}
-          >
+    <div className={className}>
+      <div className="ds:group">
+        <button
+          aria-expanded={isOpen}
+          aria-label={typeof title === 'string' ? title : ariaLabel}
+          onClick={() => void toggleOpen()}
+          className={cx(
+            'ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:group-hover:text-accent! ds:group',
+            {
+              'ds:border-b ds:border-border-gray': underline,
+              'ds:mb-2': isOpen,
+            },
+          )}
+          data-testid={dataTestId}
+        >
+          <span className="ds:mr-5 ds:w-full ds:text-left ds:hyphens-auto ds:text-heading-3 ds:group-hover:underline">
+            {title}
+          </span>
+          <span style={{ alignSelf: caretPosition === 'top' ? 'flex-start' : 'center' }}>
             {fetchStatus === 'loading' ? <Spinner size={24} color="accent" /> : <Caret isOpen={isOpen} />}
-          </button>
-        </div>
-      ) : (
-        <div className="ds:group">
-          <button
-            aria-expanded={isOpen}
-            onClick={() => void toggleOpen()}
-            className={wrapperClassnames}
-            data-testid={dataTestId}
-          >
-            <span
-              className="ds:mr-5 ds:w-full ds:text-left ds:hyphens-auto ds:text-heading-3 ds:group-hover:underline"
-              lang={lang}
-            >
-              {title}
-            </span>
-            {fetchStatus === 'loading' ? <Spinner size={24} color="accent" /> : <Caret isOpen={isOpen} />}
-          </button>
-        </div>
-      )}
+          </span>
+        </button>
+      </div>
       {isOpen && (!fetchData || fetchStatus === 'done') && children}
     </div>
   );

--- a/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/lib/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -9,32 +9,36 @@ exports[`Accordion > renders accordion with open state by default 1`] = `
   >
     <button
       aria-expanded="true"
+      aria-label="Accordion Title"
       class="ds:cursor-pointer ds:flex ds:w-full ds:items-center ds:justify-between ds:gap-x-4 ds:group-hover:text-accent! ds:group ds:mb-2"
     >
       <span
         class="ds:mr-5 ds:w-full ds:text-left ds:hyphens-auto ds:text-heading-3 ds:group-hover:underline"
-        lang="en"
       >
         Accordion Title
       </span>
       <span
-        aria-hidden="true"
-        class="ds:text-primary-gray ds:group-hover:text-accent!"
+        style="align-self: center;"
       >
-        <svg
-          fill="currentColor"
-          height="24"
-          stroke="currentColor"
-          stroke-width="0"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          aria-hidden="true"
+          class="ds:text-primary-gray ds:group-hover:text-accent!"
         >
-          <path
-            d="M12 11.0964L7.4 15.6964L6 14.2964L12 8.29639L18 14.2964L16.6 15.6964L12 11.0964Z"
+          <svg
             fill="currentColor"
-          />
-        </svg>
+            height="24"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 11.0964L7.4 15.6964L6 14.2964L12 8.29639L18 14.2964L16.6 15.6964L12 11.0964Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
       </span>
     </button>
   </div>


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
The main issue was that when using component as the title, it was possible to have the title as a button, and the caret is already a button. This caused issues with screen readers. See the details in the linked ticket.

**Highligts**
* Use the same implementation for string or component type titles to keep things consistent. It's up to the developer to make sure that the title component doesn't contain `button` or any other HTML element that's not allowed inside a button. Tools like  `AXE linter` will most likely complain if that happens.
* Rename `titleText` -> `ariaLabel` so it's more clear.
* Remove redundant `language` prop (no one remembered it's purpose).
* Fixed unit tests: The `describe` block was cut short, so only 2 tests out of 5 were actually run 🤯.
* Tested all `Accordion` usages in yksilö UI with `npm link` to make sure that nothing broke.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2059
