### PR TITLE
OPHJOD-2348: Add UserButton & MenuButton components

### DIFF
--- a/lib/components/NavigationBar/LanguageButton.stories.tsx
+++ b/lib/components/NavigationBar/LanguageButton.stories.tsx
@@ -1,8 +1,6 @@
 import type { StoryObj } from '@storybook/react-vite';
-import { useRef, useState } from 'storybook/preview-api';
 import type { TitledMeta } from '../../utils';
 
-import React from 'react';
 import { LanguageButton } from './LanguageButton';
 
 const meta = {
@@ -14,22 +12,6 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof meta>;
-
-const Render = (args: Story['args']) => {
-  const [langMenuOpen, setLangMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const handleBlur = () => setLangMenuOpen(false);
-  return (
-    <LanguageButton
-      {...args}
-      onClick={() => setLangMenuOpen(!langMenuOpen)}
-      langMenuOpen={langMenuOpen}
-      menuRef={menuRef}
-      onMenuBlur={handleBlur}
-      onMenuClick={() => setLangMenuOpen(false)}
-    />
-  );
-};
 
 export const Default: Story = {
   parameters: {
@@ -50,11 +32,6 @@ export const Default: Story = {
       sv: { change: 'Andra språk.', label: 'På svenska' },
       en: { change: 'Change language.', label: 'In English' },
     },
-    onClick: () => {},
-    langMenuOpen: false,
-    menuRef: React.createRef(),
-    onMenuBlur: () => {},
-    onMenuClick: () => {},
     language: 'fi',
     generateLocalizedPath: (code: string) => `/${code}`,
     LinkComponent: ({ children, className, ...rest }) => (
@@ -70,5 +47,4 @@ export const Default: Story = {
       </div>
     ),
   ],
-  render: Render,
 };

--- a/lib/components/NavigationBar/LanguageButton.test.tsx
+++ b/lib/components/NavigationBar/LanguageButton.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { LanguageButton } from './LanguageButton';
 import { LangCode } from './types';
 
@@ -18,45 +18,43 @@ const LinkComponent = ({ href = '#', children }: { href?: string; children: Reac
 
 const generateLocalizedPath = (lang: string) => `/${lang}/path`;
 
+const baseProps = () => ({
+  language: 'fi' as const,
+  supportedLanguageCodes: ['fi', 'en', 'sv'] as LangCode[],
+  generateLocalizedPath,
+  LinkComponent,
+  translations,
+  dataTestId: 'language-button',
+});
+
 describe('LanguageButton', () => {
-  const baseProps = () => ({
-    onClick: vi.fn(),
-    langMenuOpen: false,
-    menuRef: React.createRef<HTMLDivElement>(),
-    onMenuBlur: vi.fn(),
-    onMenuClick: vi.fn(),
-    language: 'fi' as const,
-    supportedLanguageCodes: ['fi', 'en', 'sv'] as LangCode[],
-    generateLocalizedPath,
-    LinkComponent,
-    translations,
-    dataTestId: 'language-button',
+  it('should toggle menu open and closed on consecutive clicks', () => {
+    const { getByTestId, queryByTestId } = render(<LanguageButton {...baseProps()} />);
+    const trigger = getByTestId('language-button-trigger');
+    fireEvent.click(trigger);
+    expect(getByTestId('language-button-menu')).not.toBeNull();
+    fireEvent.click(trigger);
+    expect(queryByTestId('language-button-menu')).toBeNull();
   });
 
-  it('invokes onClick when trigger button is clicked', () => {
-    const mockOnClick = vi.fn();
-    render(<LanguageButton {...baseProps()} onClick={mockOnClick} />);
-    fireEvent.click(screen.getByTestId('language-button-trigger'));
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  it('should display current language label', () => {
+    const { getByText } = render(<LanguageButton {...baseProps()} language="sv" />);
+    expect(getByText('Svenska')).not.toBeNull();
+  });
+});
+
+describe('Snapshot', () => {
+  it('should render with defaults', () => {
+    const { container } = render(<LanguageButton {...baseProps()} />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('fires onMenuBlur when menu loses focus', () => {
-    const mockOnMenuBlur = vi.fn();
-    render(<LanguageButton {...baseProps()} onMenuBlur={mockOnMenuBlur} langMenuOpen={true} />);
-    const menuWrapper = screen.getByTestId('language-button-menu');
-    fireEvent.blur(menuWrapper);
-    expect(mockOnMenuBlur).toHaveBeenCalledTimes(1);
-  });
-
-  describe('Snapshot', () => {
-    it('should render with defaults', () => {
-      const { container } = render(<LanguageButton {...baseProps()} />);
-      expect(container.firstChild).toMatchSnapshot();
-    });
-
-    it('should render with menu open', () => {
-      const { container } = render(<LanguageButton {...baseProps()} langMenuOpen />);
-      expect(container.firstChild).toMatchSnapshot();
-    });
+  it('should render with menu open (after click)', () => {
+    const { container, getByTestId } = render(<LanguageButton {...baseProps()} />);
+    const trigger = getByTestId('language-button-trigger');
+    fireEvent.click(trigger);
+    const menu = getByTestId('language-button-menu');
+    expect(menu).not.toBeNull();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/lib/components/NavigationBar/LanguageButton.tsx
+++ b/lib/components/NavigationBar/LanguageButton.tsx
@@ -1,15 +1,9 @@
 import React, { JSX } from 'react';
 import { useMediaQueries } from '../../hooks/useMediaQueries';
+import { usePopupMenu } from '../../hooks/usePopupMenu';
 import { JodCaretDown, JodCaretUp, JodLanguage } from '../../icons';
 import { LanguageMenu } from './LanguageMenu';
-import { LangCode, LanguageMenuProps, LanguageTranslations } from './types';
-
-interface LanguageButtonProps extends LanguageMenuProps {
-  langMenuOpen: boolean;
-  menuRef: React.RefObject<HTMLDivElement | null>;
-  onMenuBlur: (event: React.FocusEvent<HTMLDivElement>) => void;
-  onMenuClick: () => void;
-}
+import { LangCode, LanguageButtonProps, LanguageTranslations } from './types';
 
 const getLanguageOrder = (current: LangCode, translations: LanguageTranslations): JSX.Element => {
   const orderMap: Record<LangCode, LangCode[]> = {
@@ -31,11 +25,6 @@ const getLanguageOrder = (current: LangCode, translations: LanguageTranslations)
 };
 
 export const LanguageButton = ({
-  onClick,
-  langMenuOpen,
-  menuRef,
-  onMenuBlur,
-  onMenuClick,
   language,
   supportedLanguageCodes,
   generateLocalizedPath,
@@ -44,6 +33,7 @@ export const LanguageButton = ({
   dataTestId,
 }: LanguageButtonProps) => {
   const { md, sm } = useMediaQueries();
+  const { isOpen: langMenuOpen, close: closeLanguageMenu, triggerProps, menuProps } = usePopupMenu();
   const carets = md ? <>{langMenuOpen ? <JodCaretUp size={20} /> : <JodCaretDown size={20} />}</> : null;
 
   const positionClass = sm ? 'ds:absolute ds:right-0' : 'ds:fixed ds:left-4 ds:right-4';
@@ -51,7 +41,7 @@ export const LanguageButton = ({
   return (
     <div className="ds:relative" data-testid={dataTestId}>
       <button
-        onClick={onClick}
+        {...triggerProps}
         className="ds:flex ds:flex-col ds:md:flex-row ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-y-2 ds:gap-x-3"
         data-testid={dataTestId ? `${dataTestId}-trigger` : undefined}
       >
@@ -64,8 +54,7 @@ export const LanguageButton = ({
       </button>
       {langMenuOpen && (
         <div
-          ref={menuRef}
-          onBlur={onMenuBlur}
+          {...menuProps}
           className={`ds:z-60 ds:flex ds:justify-center ds:translate-y-8 ${positionClass}`}
           data-testid={dataTestId ? `${dataTestId}-menu` : undefined}
         >
@@ -74,7 +63,7 @@ export const LanguageButton = ({
             language={language}
             generateLocalizedPath={generateLocalizedPath}
             LinkComponent={LinkComponent}
-            onClick={onMenuClick}
+            onClick={closeLanguageMenu}
             translations={translations}
             dataTestId={dataTestId}
           />

--- a/lib/components/NavigationBar/LanguageMenu.tsx
+++ b/lib/components/NavigationBar/LanguageMenu.tsx
@@ -11,9 +11,13 @@ const ListItems = ({
   dataTestId,
 }: LanguageMenuProps) => {
   return supportedLanguageCodes.map((lng) => (
-    <div className="ds:flex ds:flex-row ds:justify-center ds:items-center ds:gap-2 ds:w-full" key={lng}>
+    <div
+      className="ds:flex ds:flex-row ds:justify-center ds:items-center ds:gap-2 ds:w-full"
+      key={lng}
+      aria-current={lng === language}
+    >
       <div className="ds:w-5 ds:px-2">
-        {lng === language && <JodCircle size={12} className="ds:text-secondary-1" />}
+        {lng === language && <JodCircle role="presentation" size={12} className="ds:text-secondary-1" />}
       </div>
       <LinkComponent
         to={generateLocalizedPath(lng)}

--- a/lib/components/NavigationBar/MenuButton.tsx
+++ b/lib/components/NavigationBar/MenuButton.tsx
@@ -1,0 +1,22 @@
+import { JodMenu } from '../../icons';
+
+export interface MenuButtonProps {
+  onClick: () => void;
+  ariaLabel: string;
+  label: string;
+}
+
+export const MenuButton = ({ onClick, ariaLabel, label }: MenuButtonProps) => {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className="ds:flex ds:flex-col ds:md:flex-row ds:gap-2 ds:md:gap-3 ds:justify-center ds:items-center ds:select-none ds:cursor-pointer"
+      data-testid="open-nav-menu"
+      aria-expanded={false}
+    >
+      <JodMenu className="ds:mx-auto" />
+      <span className="ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px]">{label}</span>
+    </button>
+  );
+};

--- a/lib/components/NavigationBar/NavigationBar.stories.tsx
+++ b/lib/components/NavigationBar/NavigationBar.stories.tsx
@@ -1,8 +1,6 @@
 import type { ArgTypes, ReactRenderer, StoryObj } from '@storybook/react-vite';
 import { PartialStoryFn } from 'storybook/internal/types';
-import { useRef, useState } from 'storybook/preview-api';
-import { JodCaretDown, JodMenu, JodUser } from '../../icons';
-import { useMediaQueries } from '../../main';
+import { MenuButton, UserButton } from '../../main';
 import type { TitledMeta } from '../../utils';
 import { LanguageButton } from './LanguageButton';
 import { NavigationBar, NavigationBarProps } from './NavigationBar';
@@ -81,59 +79,47 @@ export const Default: Story = {
     showServiceBar: false,
   },
   render: (args) => {
-    const { md } = useMediaQueries();
-
-    const [langMenuOpen, setLangMenuOpen] = useState(false);
-    const menuRef = useRef<HTMLDivElement | null>(null);
-    const handleBlur = () => setLangMenuOpen(false);
-
-    const buttonClassNames =
-      'ds:flex ds:md:flex-row ds:flex-col ds:gap-2 ds:justify-center ds:items-center ds:select-none ds:cursor-pointer';
-
-    const menuComponent = (
-      <button className={buttonClassNames} aria-label="Avaa valikko">
-        <JodMenu size={24} className="ds:mx-auto" />
-        <span className="ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px]">Valikko</span>
-      </button>
-    );
-
-    const languageButtonComponent = (
-      <LanguageButton
-        supportedLanguageCodes={['fi', 'sv', 'en']}
-        onClick={() => setLangMenuOpen(!langMenuOpen)}
-        langMenuOpen={langMenuOpen}
-        menuRef={menuRef}
-        language="fi"
-        onMenuBlur={handleBlur}
-        onMenuClick={() => setLangMenuOpen(false)}
-        translations={{
-          fi: { change: 'Vaihda kieli.', label: 'Suomeksi' },
-          sv: { change: 'Andra språk.', label: 'På svenska' },
-          en: { change: 'Change language.', label: 'In English' },
-        }}
-        generateLocalizedPath={(code: string) => `/${code}`}
-        LinkComponent={({ children, className, ...rest }) => (
-          <a href="/#" className={className} {...rest}>
-            {children}
-          </a>
-        )}
-      />
-    );
-
-    const userButtonComponent = (
-      <button className={buttonClassNames}>
-        <JodUser size={24} className="ds:mx-auto" />
-        <span className="ds:whitespace-nowrap ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px]">Juho-Henrik</span>
-        {md && <JodCaretDown size={20} />}
-      </button>
-    );
-
     return (
       <NavigationBar
         {...args}
-        userButtonComponent={userButtonComponent}
-        languageButtonComponent={languageButtonComponent}
-        menuComponent={menuComponent}
+        userButtonComponent={
+          <UserButton
+            firstName="Juho-Henrik"
+            isLoggedIn
+            loginLabel="Kirjaudu"
+            profileLabel="Osaamisprofiilini"
+            logoutLabel="Kirjaudu ulos"
+            onLogout={() => console.log('logout')}
+            ProfileLinkComponent={({ children, className, ...rest }) => (
+              <a href="/#" className={className} {...rest}>
+                {children}
+              </a>
+            )}
+            LoginLinkComponent={({ children, className, ...rest }) => (
+              <a href="/#" className={className} {...rest}>
+                {children}
+              </a>
+            )}
+          />
+        }
+        languageButtonComponent={
+          <LanguageButton
+            supportedLanguageCodes={['fi', 'sv', 'en']}
+            language="fi"
+            translations={{
+              fi: { change: 'Vaihda kieli.', label: 'Suomeksi' },
+              sv: { change: 'Andra språk.', label: 'På svenska' },
+              en: { change: 'Change language.', label: 'In English' },
+            }}
+            generateLocalizedPath={(code: string) => `/${code}`}
+            LinkComponent={({ children, className, ...rest }) => (
+              <a href="/#" className={className} {...rest}>
+                {children}
+              </a>
+            )}
+          />
+        }
+        menuComponent={<MenuButton ariaLabel="Avaa valikko" label="Valikko" onClick={() => console.log('open menu')} />}
       />
     );
   },

--- a/lib/components/NavigationBar/UserButton.tsx
+++ b/lib/components/NavigationBar/UserButton.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { useMediaQueries } from '../../hooks/useMediaQueries';
+import { usePopupMenu } from '../../hooks/usePopupMenu';
+import { JodCaretDown, JodCaretUp, JodUser } from '../../icons';
+import { LinkComponent } from '../../main';
+import { PopupList, PopupListItem } from '../PopupList/PopupList';
+
+interface UserButtonProps {
+  firstName?: string;
+  profileLabel: string;
+  ProfileLinkComponent: React.ComponentType<LinkComponent & { onClick: () => void }>;
+  isLoggedIn: boolean;
+  loginLabel: string;
+  LoginLinkComponent: React.ComponentType<LinkComponent>;
+  logoutLabel: string;
+  onLogout: () => void;
+}
+
+export const UserButton = ({
+  firstName,
+  profileLabel,
+  ProfileLinkComponent,
+  isLoggedIn,
+  loginLabel,
+  LoginLinkComponent,
+  logoutLabel,
+  onLogout,
+}: UserButtonProps) => {
+  const { md } = useMediaQueries();
+
+  const { isOpen: userMenuOpen, close: closeUserMenu, triggerProps, menuProps } = usePopupMenu();
+
+  const carets = md ? <>{userMenuOpen ? <JodCaretUp size={20} /> : <JodCaretDown size={20} />}</> : null;
+
+  return isLoggedIn ? (
+    <div className="relative" data-testid="user-button">
+      <button
+        {...triggerProps}
+        className="ds:flex ds:flex-col ds:md:flex-row ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-2 ds:md:gap-3"
+        data-testid="user-button-trigger"
+      >
+        <JodUser className="ds:mx-auto" />
+        <span className="ds:whitespace-nowrap ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px]">{firstName}</span>
+        {carets}
+      </button>
+      {userMenuOpen && (
+        <div
+          {...menuProps}
+          className="ds:z-60 ds:absolute ds:right-0 ds:min-w-max ds:translate-y-8 ds:transform"
+          data-testid="user-menu"
+        >
+          <PopupList classNames="gap-2">
+            <ProfileLinkComponent onClick={closeUserMenu} className="" data-testid="user-menu-profile">
+              <PopupListItem>{profileLabel}</PopupListItem>
+            </ProfileLinkComponent>
+
+            <button
+              type="button"
+              onClick={() => {
+                closeUserMenu();
+                onLogout();
+              }}
+              className="ds:cursor-pointer ds:w-full"
+              data-testid="user-menu-logout"
+            >
+              <PopupListItem classNames="ds:w-full">{logoutLabel}</PopupListItem>
+            </button>
+          </PopupList>
+        </div>
+      )}
+    </div>
+  ) : (
+    <LoginLinkComponent
+      className="ds:flex ds:flex-col ds:md:flex-row ds:gap-2 ds:md:gap-3 ds:justify-center ds:items-center ds:select-none ds:cursor-pointer"
+      data-testid="user-login-link"
+    >
+      <JodUser className="ds:mx-auto" />
+      <span className="ds:whitespace-nowrap ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px]">{loginLabel}</span>
+    </LoginLinkComponent>
+  );
+};

--- a/lib/components/NavigationBar/UserButton.tsx
+++ b/lib/components/NavigationBar/UserButton.tsx
@@ -33,7 +33,7 @@ export const UserButton = ({
   const carets = md ? <>{userMenuOpen ? <JodCaretUp size={20} /> : <JodCaretDown size={20} />}</> : null;
 
   return isLoggedIn ? (
-    <div className="relative" data-testid="user-button">
+    <div className="ds:relative" data-testid="user-button">
       <button
         {...triggerProps}
         className="ds:flex ds:flex-col ds:md:flex-row ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-2 ds:md:gap-3"
@@ -49,7 +49,7 @@ export const UserButton = ({
           className="ds:z-60 ds:absolute ds:right-0 ds:min-w-max ds:translate-y-8 ds:transform"
           data-testid="user-menu"
         >
-          <PopupList classNames="gap-2">
+          <PopupList classNames="ds:gap-2">
             <ProfileLinkComponent onClick={closeUserMenu} className="" data-testid="user-menu-profile">
               <PopupListItem>{profileLabel}</PopupListItem>
             </ProfileLinkComponent>

--- a/lib/components/NavigationBar/__snapshots__/LanguageButton.test.tsx.snap
+++ b/lib/components/NavigationBar/__snapshots__/LanguageButton.test.tsx.snap
@@ -1,11 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`LanguageButton > Snapshot > should render with defaults 1`] = `
+exports[`Snapshot > should render with defaults 1`] = `
 <div
   class="ds:relative"
   data-testid="language-button"
 >
   <button
+    aria-expanded="false"
+    aria-haspopup="true"
     class="ds:flex ds:flex-col ds:md:flex-row ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-y-2 ds:gap-x-3"
     data-testid="language-button-trigger"
   >
@@ -54,12 +56,14 @@ exports[`LanguageButton > Snapshot > should render with defaults 1`] = `
 </div>
 `;
 
-exports[`LanguageButton > Snapshot > should render with menu open 1`] = `
+exports[`Snapshot > should render with menu open (after click) 1`] = `
 <div
   class="ds:relative"
   data-testid="language-button"
 >
   <button
+    aria-expanded="true"
+    aria-haspopup="true"
     class="ds:flex ds:flex-col ds:md:flex-row ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-y-2 ds:gap-x-3"
     data-testid="language-button-trigger"
   >
@@ -116,6 +120,7 @@ exports[`LanguageButton > Snapshot > should render with menu open 1`] = `
         class="ds:inline-flex ds:flex-col ds:items-start ds:rounded-lg ds:bg-white ds:py-6 ds:px-4 ds:shadow-border ds:w-[229px] ds:gap-2"
       >
         <div
+          aria-current="true"
           class="ds:flex ds:flex-row ds:justify-center ds:items-center ds:gap-2 ds:w-full"
         >
           <div
@@ -125,6 +130,7 @@ exports[`LanguageButton > Snapshot > should render with menu open 1`] = `
               class="ds:text-secondary-1"
               fill="currentColor"
               height="12"
+              role="presentation"
               stroke="currentColor"
               stroke-width="0"
               viewBox="0 0 12 12"
@@ -147,6 +153,7 @@ exports[`LanguageButton > Snapshot > should render with menu open 1`] = `
           </a>
         </div>
         <div
+          aria-current="false"
           class="ds:flex ds:flex-row ds:justify-center ds:items-center ds:gap-2 ds:w-full"
         >
           <div
@@ -160,6 +167,7 @@ exports[`LanguageButton > Snapshot > should render with menu open 1`] = `
           </a>
         </div>
         <div
+          aria-current="false"
           class="ds:flex ds:flex-row ds:justify-center ds:items-center ds:gap-2 ds:w-full"
         >
           <div

--- a/lib/components/NavigationBar/types.ts
+++ b/lib/components/NavigationBar/types.ts
@@ -14,8 +14,7 @@ export type LanguageMenuLinkComponent = React.ComponentType<{
   className?: string;
 }>;
 
-export interface LanguageMenuProps {
-  onClick: () => void;
+export interface LanguageButtonProps {
   /** Current language in use */
   language: LangCode;
   /** Languages that are in use from supported ones  */
@@ -24,6 +23,10 @@ export interface LanguageMenuProps {
   LinkComponent: LanguageMenuLinkComponent;
   translations: LanguageTranslations;
   dataTestId?: string;
+}
+
+export interface LanguageMenuProps extends LanguageButtonProps {
+  onClick: () => void;
 }
 
 export type LanguageTranslations = Record<LangCode, LanguageMeta>;

--- a/lib/hooks/usePopupMenu/index.tsx
+++ b/lib/hooks/usePopupMenu/index.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+interface UsePopupMenuOptions {
+  closeOnEscape?: boolean;
+  closeOnClickOutside?: boolean;
+  closeOnFocusOut?: boolean;
+}
+
+export const usePopupMenu = (options: UsePopupMenuOptions = {}) => {
+  const { closeOnEscape = true, closeOnClickOutside = true, closeOnFocusOut = true } = options;
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+
+  const close = React.useCallback(() => setIsOpen(false), []);
+  const open = React.useCallback(() => setIsOpen(true), []);
+  const toggle = React.useCallback(() => setIsOpen((prev) => !prev), []);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (closeOnEscape && event.key === 'Escape') {
+        close();
+        triggerRef.current?.focus();
+      }
+    };
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!closeOnClickOutside) {
+        return;
+      }
+
+      const target = event.target as Node;
+      const isClickInsideTrigger = triggerRef.current?.contains(target);
+      const isClickInsideMenu = menuRef.current?.contains(target);
+
+      if (!isClickInsideTrigger && !isClickInsideMenu) {
+        close();
+      }
+    };
+
+    const handleFocusOut = (event: FocusEvent) => {
+      if (!closeOnFocusOut) {
+        return;
+      }
+
+      const relatedTarget = event.relatedTarget as Node | null;
+      const isFocusInsideTrigger = triggerRef.current?.contains(relatedTarget);
+      const isFocusInsideMenu = menuRef.current?.contains(relatedTarget);
+
+      if (!isFocusInsideTrigger && !isFocusInsideMenu) {
+        close();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('focusout', handleFocusOut);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('focusout', handleFocusOut);
+    };
+  }, [isOpen, close, closeOnEscape, closeOnClickOutside, closeOnFocusOut]);
+
+  return {
+    isOpen,
+    open,
+    close,
+    toggle,
+    triggerRef,
+    menuRef,
+    triggerProps: {
+      ref: triggerRef,
+      onClick: toggle,
+      'aria-expanded': isOpen,
+      'aria-haspopup': true,
+    },
+    menuProps: {
+      ref: menuRef,
+    },
+  };
+};

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -52,6 +52,7 @@ export { MediaCard } from './components/MediaCard/MediaCard';
 export { Modal } from './components/Modal/Modal';
 export { LanguageButton } from './components/NavigationBar/LanguageButton';
 export { NavigationBar } from './components/NavigationBar/NavigationBar';
+export { UserButton } from './components/NavigationBar/UserButton';
 export {
   ExternalLinkSections,
   LanguageSelection,

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -51,6 +51,7 @@ export { MatomoTracker } from './components/MatomoTracker/MatomoTracker';
 export { MediaCard } from './components/MediaCard/MediaCard';
 export { Modal } from './components/Modal/Modal';
 export { LanguageButton } from './components/NavigationBar/LanguageButton';
+export { MenuButton } from './components/NavigationBar/MenuButton';
 export { NavigationBar } from './components/NavigationBar/NavigationBar';
 export { UserButton } from './components/NavigationBar/UserButton';
 export {


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
**As a draft to get comments already what others think. Will push branch to yksilo-ui where this can be linked with and easier to see in actual use and see how menus closes etc.**

- Add `UserButton` component
- Add `MenuButton` component
- Add `usePopupMenu `hook
  - Trying to simplify the logic of closing menus
- Improve `LanguageButton` accessibility
  - selected language icon for screenreaders not read as 'image' anymore
  - mark the currently selected language with `aria-current`


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2348
