### PR TITLE
OPHJOD-3307: Fix tabbing into tooltips without custom portaling

### DIFF
--- a/lib/components/AiInfoButton/AiInfoButton.tsx
+++ b/lib/components/AiInfoButton/AiInfoButton.tsx
@@ -26,14 +26,6 @@ export const AiInfoButton = ({
   const handleClick: React.MouseEventHandler<HTMLElement> = (event) => {
     event.stopPropagation();
   };
-  const portalRootRef = React.useRef<HTMLDivElement | null>(null);
-  const [portalRoot, setPortalRoot] = React.useState<HTMLDivElement | null>(null);
-
-  React.useEffect(() => {
-    if (portalRootRef.current) {
-      setPortalRoot(portalRootRef.current);
-    }
-  }, []);
   const triggerId = React.useId();
   const contentId = React.useId();
   const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -55,7 +47,6 @@ export const AiInfoButton = ({
         <JodAiGradient className={cx('ds:text-secondary-gray', className)} aria-label={ariaLabel} size={size} />
       </TooltipTrigger>
 
-      <div ref={portalRootRef} />
       <TooltipContent
         id={contentId}
         aria-hidden="false"
@@ -68,7 +59,6 @@ export const AiInfoButton = ({
             triggerRef.current?.focus();
           }
         }}
-        portalRoot={portalRoot}
       >
         {tooltipContent}
       </TooltipContent>

--- a/lib/components/AiInfoButton/__snapshots__/AiInfoButton.test.tsx.snap
+++ b/lib/components/AiInfoButton/__snapshots__/AiInfoButton.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`AiInfoButton > renders the button with tooltip 1`] = `
   aria-expanded="true"
   aria-label="Info button"
   class="ds:cursor-pointer"
+  data-floating-ui-inert=""
   data-testid="aiinfo"
   id="_r_0_"
   type="button"

--- a/lib/components/Tooltip/TooltipContent.tsx
+++ b/lib/components/Tooltip/TooltipContent.tsx
@@ -1,12 +1,18 @@
-import { FloatingArrow, FloatingPortal, useMergeRefs } from '@floating-ui/react';
+import {
+  FloatingArrow,
+  FloatingFocusManager,
+  type FloatingFocusManagerProps,
+  FloatingPortal,
+  useMergeRefs,
+} from '@floating-ui/react';
 import React from 'react';
-import { tidyClasses } from '../../utils';
+import { cx } from '../../cva';
 import { ARROW_HEIGHT, useTooltipContext } from './utils';
 
 type TooltipContentProps = React.HTMLProps<HTMLDivElement> & {
-  arrowClassName?: string;
   testId?: string;
-  portalRoot?: HTMLElement | null;
+  initialFocus?: FloatingFocusManagerProps['initialFocus'];
+  closeOnFocusOut?: FloatingFocusManagerProps['closeOnFocusOut'];
 };
 export const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentProps>(
   function TooltipContent(props, propRef) {
@@ -31,46 +37,58 @@ export const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentPro
       return null;
     }
 
-    const { testId, arrowClassName, portalRoot, ...rest } = props;
+    const {
+      testId,
+      closeOnFocusOut = true, // Close tooltip when focus moves outside
+      initialFocus = -1, // Don't focus any element inside the tooltip by default
+      ...rest
+    } = props;
 
     return (
-      <FloatingPortal root={portalRoot ?? document.body}>
-        <div
-          aria-hidden="true"
-          role="tooltip"
-          className={tidyClasses([
-            'ds:max-w-[280px]',
-            'ds:sm:max-w-[320px]',
-            'ds:rounded',
-            'ds:p-4',
-            'ds:bg-primary-gray',
-            'ds:text-body-xs',
-            'ds:font-arial',
-            'ds:text-white',
-            'ds:z-50',
-          ])}
-          ref={ref}
-          style={{
-            ...tooltipContext.floatingStyles,
-            // Hide completely until positioned
-            visibility: isReady ? 'visible' : 'hidden',
-          }}
-          data-testid={testId}
-          {...tooltipContext.getFloatingProps(rest)}
-          onBlur={() => tooltipContext.setOpen(false)}
+      <FloatingPortal>
+        <FloatingFocusManager
+          // eslint-disable-next-line react-hooks/refs
+          context={tooltipContext.context}
+          modal={false}
+          initialFocus={initialFocus}
+          closeOnFocusOut={closeOnFocusOut}
         >
-          {props.children}
-          <FloatingArrow
-            // eslint-disable-next-line react-hooks/refs
-            ref={tooltipContext.arrowRef}
-            // eslint-disable-next-line react-hooks/refs
-            context={tooltipContext.context}
-            className={arrowClassName ?? 'ds:fill-primary-gray'}
-            width={ARROW_HEIGHT * 2}
-            height={ARROW_HEIGHT}
-            data-testid={testId ? `${testId}-arrow` : undefined}
-          />
-        </div>
+          <div
+            aria-hidden="true"
+            role="tooltip"
+            className={cx([
+              'ds:max-w-[280px]',
+              'ds:sm:max-w-[320px]',
+              'ds:rounded',
+              'ds:p-4',
+              'ds:bg-primary-gray',
+              'ds:text-body-xs',
+              'ds:font-arial',
+              'ds:text-white',
+              'ds:z-50',
+            ])}
+            ref={ref}
+            style={{
+              ...tooltipContext.floatingStyles,
+              // Hide completely until positioned
+              visibility: isReady ? 'visible' : 'hidden',
+            }}
+            data-testid={testId}
+            {...tooltipContext.getFloatingProps(rest)}
+          >
+            {props.children}
+            <FloatingArrow
+              // eslint-disable-next-line react-hooks/refs
+              ref={tooltipContext.arrowRef}
+              // eslint-disable-next-line react-hooks/refs
+              context={tooltipContext.context}
+              className="ds:fill-primary-gray"
+              width={ARROW_HEIGHT * 2}
+              height={ARROW_HEIGHT}
+              data-testid={testId ? `${testId}-arrow` : undefined}
+            />
+          </div>
+        </FloatingFocusManager>
       </FloatingPortal>
     );
   },


### PR DESCRIPTION
## Description
* Use `FloatingFocusManager` from `floating-ui/react` to handle focus/tabbing into tooltips.
  * This eliminated the need for attaching floating portal to specific elements. The portal gets attached to document body by default, which prevents the tooltips getting cut off in modals.
  * Tested via `npm link` that tooltips work like they should and any links inside are tabbable (AI info buttons, tooltips in `HowToUse` component in yksilö ui front page etc.)
* Removed unused `arrowClassName` prop in `TooltipContent`.
* `tidyClasses` -> `cx`.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-3307
