### PR TITLE
OPHJOD-3334: Support automatic modal opening based on consent status

### DIFF
--- a/lib/components/CookieConsent/CookieConsentProvider.tsx
+++ b/lib/components/CookieConsent/CookieConsentProvider.tsx
@@ -16,6 +16,8 @@ const shouldReloadAfterConsentChange = (previousConsent: CookieConsent | null, n
 
 export interface CookieConsentProviderProps {
   children: React.ReactNode;
+  /** Whether to automatically open the consent modal if no consent has been given yet. */
+  automaticallyOpen?: boolean;
   /** Service variant for button colors */
   serviceVariant: ServiceVariant;
   /** Translations for the modal and guard components */
@@ -44,7 +46,12 @@ export interface CookieConsentProviderProps {
 }
 
 /** CookieConsentProvider manages the state of cookie consent and provides it to the rest of the app via context. It also renders the CookieConsentModal, which is shown when the user needs to give or change their consent. */
-export const CookieConsentProvider = ({ children, serviceVariant, translations }: CookieConsentProviderProps) => {
+export const CookieConsentProvider = ({
+  children,
+  automaticallyOpen = true,
+  serviceVariant,
+  translations,
+}: CookieConsentProviderProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [consent, setConsent] = React.useState<CookieConsent | null>(null);
 
@@ -52,10 +59,10 @@ export const CookieConsentProvider = ({ children, serviceVariant, translations }
     const data = readCookieConsent();
     if (data) {
       setConsent(data.consent);
-    } else {
+    } else if (automaticallyOpen) {
       setIsOpen(true);
     }
-  }, []);
+  }, [automaticallyOpen]);
 
   const open = React.useCallback(() => {
     setIsOpen(true);


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Support automatic modal opening based on consent status
## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3334
