### PR TITLE
OPHJOD-3340: Add prefers-reduced-motion check to useMediaQueries hook and disable animations if reduced motion is preferred

### DIFF
--- a/lib/components/Accordion/Accordion.tsx
+++ b/lib/components/Accordion/Accordion.tsx
@@ -2,6 +2,7 @@ import { Transition } from '@headlessui/react';
 import React from 'react';
 import { cx } from '../../cva';
 import { JodCaretDown, JodCaretUp } from '../../icons';
+import { useMediaQueries } from '../../main';
 import { Spinner } from '../Spinner/Spinner';
 
 type TitleProps =
@@ -80,6 +81,8 @@ export const Accordion = ({
   const isControlled = controlledIsOpen !== undefined;
   const isOpen = isControlled ? controlledIsOpen : internalIsOpen;
   const setIsOpen = isControlled && controlledSetIsOpen ? controlledSetIsOpen : setInternalIsOpen;
+  const { reduceMotion } = useMediaQueries();
+  const shouldAnimate = reduceMotion ? false : animated;
 
   // Reset the state when the children change
   React.useEffect(() => {
@@ -143,7 +146,7 @@ export const Accordion = ({
           </span>
         </button>
       </div>
-      {animated ? (
+      {shouldAnimate ? (
         <>
           <Transition
             ref={contentRef}

--- a/lib/hooks/useMediaQueries/index.ts
+++ b/lib/hooks/useMediaQueries/index.ts
@@ -28,5 +28,6 @@ export const useMediaQueries = () => {
     md: useMediaQuery(`(min-width: ${md})`),
     lg: useMediaQuery(`(min-width: ${lg})`),
     xl: useMediaQuery(`(min-width: ${xl})`),
+    reduceMotion: useMediaQuery('(prefers-reduced-motion: reduce)'),
   };
 };

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,4 +1,11 @@
+import { MotionGlobalConfig } from 'motion';
 import './index.css';
+
+// Disable animations in modals for users who prefer reduced motion
+const reduceMotionPreference = globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;
+if (reduceMotionPreference) {
+  MotionGlobalConfig.skipAnimations = true;
+}
 
 export { cva, cx } from './cva';
 export { clamp, tidyClasses, type AnimationMode, type ModalAnimations } from './utils';
@@ -62,8 +69,8 @@ export {
   MenuButton,
   NavigationBar,
   NoteStackProvider,
-  UserButton,
   useNoteStack,
+  UserButton,
   type PermanentNoteStackElement,
   type TemporaryNoteStackElement,
 } from './components/NavigationBar';


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
* Add prefers-reduced-motion check to useMediaQueries hook
* Disable modal and accordion animations if reduced motion is preferred
  * Tested with Chrome CSS media feature emulation inside Storybook, and also with yksilö UI Playwright tests with `npm link`

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3340
