### PR TITLE
OPHJOD-3337: Add language button to Cookie Consent

### DIFF
--- a/lib/components/CookieConsent/CookieConsent.stories.tsx
+++ b/lib/components/CookieConsent/CookieConsent.stories.tsx
@@ -1,7 +1,7 @@
 import type { StoryObj } from '@storybook/react-vite';
 import type { TitledMeta } from '../../utils';
 
-import { Button } from '../../main';
+import { Button, LanguageButton } from '../../main';
 import { useCookieConsent } from './CookieConsentContext';
 import { CookieConsentGuard } from './CookieConsentGuard';
 import { CookieConsentProvider } from './CookieConsentProvider';
@@ -41,6 +41,9 @@ export const Default: Story = {
     children: {
       control: false,
     },
+    languageButtonComponent: {
+      control: false,
+    },
   },
   args: {
     children: (
@@ -49,6 +52,24 @@ export const Default: Story = {
       </CookieConsentGuard>
     ),
     serviceVariant: 'yksilo',
+    languageButtonComponent: (
+      <LanguageButton
+        serviceVariant="yksilo"
+        supportedLanguageCodes={['fi', 'sv', 'en']}
+        language="fi"
+        translations={{
+          fi: { change: 'Vaihda kieli.', label: 'Suomeksi' },
+          sv: { change: 'Andra språk.', label: 'På svenska' },
+          en: { change: 'Change language.', label: 'In English' },
+        }}
+        generateLocalizedPath={(code: string) => `/${code}`}
+        linkComponent={({ children, className, ...rest }) => (
+          <a href="/#" className={className} {...rest}>
+            {children}
+          </a>
+        )}
+      />
+    ),
     translations: {
       modal: {
         name: 'Evästeasetukset',
@@ -61,7 +82,7 @@ export const Default: Story = {
         statisticsDescription: 'Seuraamme palvelun kävijämääriä Matomon avulla. Tähän ei kysytä erikseen suostumusta.',
         readMoreLabel: 'Lue lisää evästeistämme ja tietosuojakäytännöistämme',
         readMoreHref: '/fi/tietosuojaseloste-ja-evasteet',
-        hereLabel: 'täältä',
+        externalLinkIconAriaLabel: 'Linkki johtaa palvelun ulkopuolelle',
         currentSelectionLabel: 'Nykyinen valintasi',
         acceptAllLabel: 'Hyväksy kaikki',
         declineOptionalLabel: 'Hyväksy vain välttämättömät',

--- a/lib/components/CookieConsent/CookieConsentContext.ts
+++ b/lib/components/CookieConsent/CookieConsentContext.ts
@@ -9,6 +9,7 @@ export const CookieConsentContext = React.createContext<{
   open: () => void;
   save: (consent: CookieConsent) => void;
   serviceVariant: ServiceVariant;
+  languageButtonComponent: React.ReactNode;
   translations: CookieConsentProviderProps['translations'];
 } | null>(null);
 

--- a/lib/components/CookieConsent/CookieConsentModal.test.tsx
+++ b/lib/components/CookieConsent/CookieConsentModal.test.tsx
@@ -50,7 +50,7 @@ describe('CookieConsentModal', () => {
     expect(screen.getByText('Necessary cookies')).toBeInTheDocument();
     expect(screen.getByText('Third-party content')).toBeInTheDocument();
 
-    const link = screen.getByRole('link', { name: 'here' });
+    const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', '/en/privacy-notice-and-cookies');
     expect(link).toHaveAttribute('target', '_blank');
   });

--- a/lib/components/CookieConsent/CookieConsentModal.tsx
+++ b/lib/components/CookieConsent/CookieConsentModal.tsx
@@ -1,3 +1,4 @@
+import { JodOpenInNew } from '../../icons';
 import { Button } from '../Button/Button';
 import { Modal } from '../Modal/Modal';
 import { useCookieConsent } from './CookieConsentContext';
@@ -8,6 +9,7 @@ export const CookieConsentModal = () => {
     isOpen,
     save,
     serviceVariant,
+    languageButtonComponent,
     translations: {
       modal: {
         name,
@@ -19,7 +21,7 @@ export const CookieConsentModal = () => {
         statisticsDescription,
         readMoreLabel,
         readMoreHref,
-        hereLabel,
+        externalLinkIconAriaLabel,
         currentSelectionLabel,
         acceptAllLabel,
         declineOptionalLabel,
@@ -44,33 +46,39 @@ export const CookieConsentModal = () => {
       name={name}
       open={isOpen}
       fullWidthContent
-      topSlot={<h2 className="ds:text-heading-2-mobile ds:sm:text-hero">{title}</h2>}
+      topSlot={
+        <div className="ds:flex ds:justify-between ds:gap-5 ds:flex-1">
+          <h2 className="ds:text-heading-2-mobile ds:sm:text-heading-1 ds:text-primary-gray">{title}</h2>
+          {languageButtonComponent}
+        </div>
+      }
       content={
         <div className="ds:px-5 ds:md:px-9 ds:pb-7">
-          <div className="ds:flex ds:flex-col ds:gap-5">
-            <p>{description}</p>
-            <div>
+          <div className="ds:flex ds:flex-col ds:gap-6 ds:sm:gap-5">
+            <p className="ds:text-body-lg-mobile ds:sm:text-body-lg ds:mt-3 ds:sm:mt-5">{description}</p>
+            <div className="ds:font-arial ds:text-body-md-mobile ds:sm:text-body-md">
               <p>{cookieCategoriesLabel}:</p>
               <ul className="ds:list-disc ds:list-inside ds:pl-5">
                 <li>{cookiesCategoriesNecessary}</li>
                 <li>{cookiesCategoriesThirdParty}</li>
               </ul>
             </div>
-            <p>{statisticsDescription}</p>
-            <p>
-              {readMoreLabel}{' '}
-              <a
-                href={readMoreHref}
-                className="ds:text-accent ds:hover:underline"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {hereLabel}
-              </a>
-              {'.'}
-            </p>
-            {consent && (
+            <div className="ds:font-arial ds:text-body-md-mobile ds:sm:text-body-md">
+              <p>{statisticsDescription}</p>
               <p>
+                <a
+                  href={readMoreHref}
+                  className="ds:flex ds:flex-row ds:gap-2 ds:text-accent ds:hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {readMoreLabel}
+                  <JodOpenInNew size={24} ariaLabel={externalLinkIconAriaLabel} />
+                </a>
+              </p>
+            </div>
+            {consent && (
+              <p className="ds:font-arial ds:text-body-md-mobile ds:sm:text-body-md">
                 {currentSelectionLabel}:{' '}
                 <strong>{consent.thirdPartyContent ? acceptAllLabel : declineOptionalLabel}</strong>
               </p>

--- a/lib/components/CookieConsent/CookieConsentProvider.test.tsx
+++ b/lib/components/CookieConsent/CookieConsentProvider.test.tsx
@@ -27,6 +27,8 @@ const mockedWriteCookieConsent = vi.mocked(writeCookieConsent);
 let originalLocation: Location;
 let reloadMock: ReturnType<typeof vi.fn>;
 
+const languageButtonComponent = <button>Language</button>;
+
 const translations = {
   modal: {
     name: 'Cookie settings',
@@ -36,9 +38,9 @@ const translations = {
     cookiesCategoriesNecessary: 'Necessary cookies',
     cookiesCategoriesThirdParty: 'Third-party content',
     statisticsDescription: 'Statistics cookies are used to collect information about how visitors use our website.',
-    readMoreLabel: 'Read more',
+    readMoreLabel: 'Read more here.',
     readMoreHref: '/en/privacy-notice-and-cookies',
-    hereLabel: 'here',
+    externalLinkIconAriaLabel: 'Link leads outside of the service',
     currentSelectionLabel: 'Current selection',
     acceptAllLabel: 'Accept all',
     declineOptionalLabel: 'Decline optional',
@@ -93,7 +95,11 @@ describe('CookieConsentProvider', () => {
     });
 
     render(
-      <CookieConsentProvider serviceVariant="yksilo" translations={translations}>
+      <CookieConsentProvider
+        serviceVariant="yksilo"
+        languageButtonComponent={languageButtonComponent}
+        translations={translations}
+      >
         <TestConsumer />
       </CookieConsentProvider>,
     );
@@ -107,7 +113,11 @@ describe('CookieConsentProvider', () => {
     mockedReadCookieConsent.mockReturnValue(null);
 
     render(
-      <CookieConsentProvider serviceVariant="yksilo" translations={translations}>
+      <CookieConsentProvider
+        serviceVariant="yksilo"
+        languageButtonComponent={<button>Language</button>}
+        translations={translations}
+      >
         <TestConsumer />
       </CookieConsentProvider>,
     );
@@ -121,7 +131,11 @@ describe('CookieConsentProvider', () => {
     const user = userEvent.setup();
 
     render(
-      <CookieConsentProvider serviceVariant="yksilo" translations={translations}>
+      <CookieConsentProvider
+        serviceVariant="yksilo"
+        languageButtonComponent={languageButtonComponent}
+        translations={translations}
+      >
         <TestConsumer />
       </CookieConsentProvider>,
     );
@@ -152,7 +166,11 @@ describe('CookieConsentProvider', () => {
     const user = userEvent.setup();
 
     render(
-      <CookieConsentProvider serviceVariant="yksilo" translations={translations}>
+      <CookieConsentProvider
+        serviceVariant="yksilo"
+        languageButtonComponent={languageButtonComponent}
+        translations={translations}
+      >
         <TestConsumer nextConsent={{ thirdPartyContent: false }} />
       </CookieConsentProvider>,
     );

--- a/lib/components/CookieConsent/CookieConsentProvider.tsx
+++ b/lib/components/CookieConsent/CookieConsentProvider.tsx
@@ -19,7 +19,9 @@ export interface CookieConsentProviderProps {
   /** Whether to automatically open the consent modal if no consent has been given yet. */
   automaticallyOpen?: boolean;
   /** Service variant for button colors */
-  serviceVariant: ServiceVariant;
+  serviceVariant?: ServiceVariant;
+  /** For rendering a language selection button in the modal */
+  languageButtonComponent: React.ReactNode;
   /** Translations for the modal and guard components */
   translations: {
     modal: {
@@ -32,7 +34,7 @@ export interface CookieConsentProviderProps {
       statisticsDescription: string;
       readMoreLabel: string;
       readMoreHref: string;
-      hereLabel: string;
+      externalLinkIconAriaLabel: string;
       currentSelectionLabel: string;
       acceptAllLabel: string;
       declineOptionalLabel: string;
@@ -49,7 +51,8 @@ export interface CookieConsentProviderProps {
 export const CookieConsentProvider = ({
   children,
   automaticallyOpen = true,
-  serviceVariant,
+  serviceVariant = 'yksilo',
+  languageButtonComponent,
   translations,
 }: CookieConsentProviderProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -89,8 +92,8 @@ export const CookieConsentProvider = ({
   );
 
   const providerValue = React.useMemo(
-    () => ({ consent, isOpen, open, save, serviceVariant, translations }),
-    [consent, isOpen, open, save, serviceVariant, translations],
+    () => ({ consent, isOpen, open, save, serviceVariant, languageButtonComponent, translations }),
+    [consent, isOpen, open, save, serviceVariant, languageButtonComponent, translations],
   );
 
   return (

--- a/lib/components/CookieConsent/CookieConsentTestUtils.tsx
+++ b/lib/components/CookieConsent/CookieConsentTestUtils.tsx
@@ -16,9 +16,9 @@ export const cookieConsentTranslations: CookieConsentContextValue['translations'
     cookiesCategoriesThirdParty: 'Third-party content',
     statisticsDescription:
       'We track the number of visitors to the service using Matomo. This does not require separate consent.',
-    readMoreLabel: 'Read more',
+    readMoreLabel: 'Read more here.',
     readMoreHref: '/en/privacy-notice-and-cookies',
-    hereLabel: 'here',
+    externalLinkIconAriaLabel: 'External link',
     currentSelectionLabel: 'Current selection',
     acceptAllLabel: 'Accept all',
     declineOptionalLabel: 'Decline optional',
@@ -36,6 +36,7 @@ export const createCookieConsentContextValue = ({
   open = vi.fn(),
   save = vi.fn(),
   serviceVariant = 'yksilo',
+  languageButtonComponent = <button>Language</button>,
   translations = cookieConsentTranslations,
 }: Partial<CookieConsentContextValue> & { consent?: CookieConsent | null } = {}): CookieConsentContextValue => ({
   consent,
@@ -43,5 +44,6 @@ export const createCookieConsentContextValue = ({
   open,
   save,
   serviceVariant,
+  languageButtonComponent,
   translations,
 });


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Add language button to Cookie Consent
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3337
