### PR TITLE
OPHJOD-3337: Fix Cookie Consent for improved layout

### DIFF
--- a/lib/components/CookieConsent/CookieConsent.stories.tsx
+++ b/lib/components/CookieConsent/CookieConsent.stories.tsx
@@ -57,6 +57,7 @@ export const Default: Story = {
         serviceVariant="yksilo"
         supportedLanguageCodes={['fi', 'sv', 'en']}
         language="fi"
+        responsive={false}
         translations={{
           fi: { change: 'Vaihda kieli.', label: 'Suomeksi' },
           sv: { change: 'Andra språk.', label: 'På svenska' },

--- a/lib/components/CookieConsent/CookieConsentModal.tsx
+++ b/lib/components/CookieConsent/CookieConsentModal.tsx
@@ -47,13 +47,13 @@ export const CookieConsentModal = () => {
       open={isOpen}
       fullWidthContent
       topSlot={
-        <div className="ds:flex ds:justify-between ds:gap-5 ds:flex-1">
+        <div className="ds:flex ds:flex-col-reverse ds:sm:flex-row ds:justify-between ds:gap-6 ds:md:gap-5 ds:flex-1">
           <h2 className="ds:text-heading-2-mobile ds:sm:text-heading-1 ds:text-primary-gray">{title}</h2>
-          {languageButtonComponent}
+          <div className="ds:self-end">{languageButtonComponent}</div>
         </div>
       }
       content={
-        <div className="ds:px-5 ds:md:px-9 ds:pb-7">
+        <div className="ds:px-5 ds:md:px-9 ds:pb-7 ds:text-primary-gray">
           <div className="ds:flex ds:flex-col ds:gap-6 ds:sm:gap-5">
             <p className="ds:text-body-lg-mobile ds:sm:text-body-lg ds:mt-3 ds:sm:mt-5">{description}</p>
             <div className="ds:font-arial ds:text-body-md-mobile ds:sm:text-body-md">
@@ -68,12 +68,14 @@ export const CookieConsentModal = () => {
               <p>
                 <a
                   href={readMoreHref}
-                  className="ds:flex ds:flex-row ds:gap-2 ds:text-accent ds:hover:underline"
+                  className="ds:text-accent ds:hover:underline"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
                   {readMoreLabel}
-                  <JodOpenInNew size={24} ariaLabel={externalLinkIconAriaLabel} />
+                  <div className="ds:inline ds:*:align-top ds:ml-2">
+                    <JodOpenInNew size={24} ariaLabel={externalLinkIconAriaLabel} className="ds:inline" />
+                  </div>
                 </a>
               </p>
             </div>

--- a/lib/components/NavigationBar/LanguageButton.tsx
+++ b/lib/components/NavigationBar/LanguageButton.tsx
@@ -2,6 +2,7 @@ import React, { JSX } from 'react';
 import { useMediaQueries } from '../../hooks/useMediaQueries';
 import { usePopupMenu } from '../../hooks/usePopupMenu';
 import { JodCaretDown, JodCaretUp, JodLanguage } from '../../icons';
+import { cx } from '../../main';
 import { LanguageMenu } from './LanguageMenu';
 import { PopupMenuWrapper } from './PopupMenuWrapper';
 import { LangCode, LanguageButtonProps, LanguageTranslations } from './types';
@@ -31,22 +32,31 @@ export const LanguageButton = ({
   supportedLanguageCodes,
   generateLocalizedPath,
   linkComponent: LinkComponent,
+  responsive = true,
   translations,
   testId,
 }: LanguageButtonProps) => {
   const { md } = useMediaQueries();
   const { isOpen: langMenuOpen, close: closeLanguageMenu, triggerProps, menuProps } = usePopupMenu();
-  const carets = md ? <>{langMenuOpen ? <JodCaretUp size={20} /> : <JodCaretDown size={20} />}</> : null;
+  const carets = md || !responsive ? <>{langMenuOpen ? <JodCaretUp size={20} /> : <JodCaretDown size={20} />}</> : null;
 
   return (
     <div className="ds:relative" data-testid={testId}>
       <button
         {...triggerProps}
-        className="ds:flex ds:flex-col ds:md:flex-row ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-y-2 ds:gap-x-3 ds:text-primary-gray"
+        className={cx(
+          'ds:flex ds:flex-col ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-y-2 ds:gap-x-3 ds:text-primary-gray',
+          (md || !responsive) && 'ds:flex-row',
+        )}
         data-testid={testId ? `${testId}-trigger` : undefined}
       >
         <JodLanguage className="mx-auto" />
-        <span className="ds:whitespace-nowrap ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px] ds:font-semibold">
+        <span
+          className={cx(
+            'ds:whitespace-nowrap ds:font-semibold',
+            responsive ? 'ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px]' : 'ds:text-[14px]',
+          )}
+        >
           {translations[language].label}
           {getLanguageOrder(language, translations)}
         </span>

--- a/lib/components/NavigationBar/__snapshots__/LanguageButton.test.tsx.snap
+++ b/lib/components/NavigationBar/__snapshots__/LanguageButton.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Snapshot > should render with defaults 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="true"
-    class="ds:flex ds:flex-col ds:md:flex-row ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-y-2 ds:gap-x-3 ds:text-primary-gray"
+    class="ds:flex ds:flex-col ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-y-2 ds:gap-x-3 ds:text-primary-gray"
     data-testid="language-button-trigger"
   >
     <svg
@@ -27,7 +27,7 @@ exports[`Snapshot > should render with defaults 1`] = `
       />
     </svg>
     <span
-      class="ds:whitespace-nowrap ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px] ds:font-semibold"
+      class="ds:whitespace-nowrap ds:font-semibold ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px]"
     >
       Suomi
       <div
@@ -64,7 +64,7 @@ exports[`Snapshot > should render with menu open (after click) 1`] = `
   <button
     aria-expanded="true"
     aria-haspopup="true"
-    class="ds:flex ds:flex-col ds:md:flex-row ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-y-2 ds:gap-x-3 ds:text-primary-gray"
+    class="ds:flex ds:flex-col ds:justify-center ds:items-center ds:select-none ds:cursor-pointer ds:gap-y-2 ds:gap-x-3 ds:text-primary-gray"
     data-testid="language-button-trigger"
   >
     <svg
@@ -83,7 +83,7 @@ exports[`Snapshot > should render with menu open (after click) 1`] = `
       />
     </svg>
     <span
-      class="ds:whitespace-nowrap ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px] ds:font-semibold"
+      class="ds:whitespace-nowrap ds:font-semibold ds:md:text-[14px] ds:sm:text-[12px] ds:text-[10px]"
     >
       Suomi
       <div

--- a/lib/components/NavigationBar/types.ts
+++ b/lib/components/NavigationBar/types.ts
@@ -25,6 +25,7 @@ export interface LanguageButtonProps {
   supportedLanguageCodes: LangCode[];
   generateLocalizedPath: (lng: string) => string;
   linkComponent: LanguageMenuLinkComponent;
+  responsive?: boolean;
   translations: LanguageTranslations;
   testId?: string;
 }


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Fix Cookie Consent for improved layout
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3337
