### PR TITLE
OPHJOD-3337: Fix align-self on desktop

### DIFF
--- a/lib/components/CookieConsent/CookieConsentModal.tsx
+++ b/lib/components/CookieConsent/CookieConsentModal.tsx
@@ -49,7 +49,7 @@ export const CookieConsentModal = () => {
       topSlot={
         <div className="ds:flex ds:flex-col-reverse ds:sm:flex-row ds:justify-between ds:gap-6 ds:md:gap-5 ds:flex-1">
           <h2 className="ds:text-heading-2-mobile ds:sm:text-heading-1 ds:text-primary-gray">{title}</h2>
-          <div className="ds:self-end">{languageButtonComponent}</div>
+          <div className="ds:md:self-auto ds:self-end">{languageButtonComponent}</div>
         </div>
       }
       content={


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
- Fix align-self on desktop
## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3337
