### PR TITLE
OPHJOD-3121: Update portal link; external by default

### DIFF
--- a/lib/components/NavigationMenu/NavigationMenu.stories.tsx
+++ b/lib/components/NavigationMenu/NavigationMenu.stories.tsx
@@ -76,6 +76,22 @@ export const Default: Story = {
   },
 };
 
+export const OnPortalPage: Story = {
+  parameters: {
+    ...parameters,
+    docs: {
+      description: {
+        story: 'NavigationMenu component for displaying a list of links.',
+      },
+    },
+  },
+  render: DefaultRender,
+  args: {
+    ...baseProps,
+    portalExternal: false,
+  },
+};
+
 export const WithoutMenuSection: Story = {
   parameters: {
     ...parameters,

--- a/lib/components/NavigationMenu/NavigationMenu.tsx
+++ b/lib/components/NavigationMenu/NavigationMenu.tsx
@@ -39,6 +39,8 @@ export interface NavigationMenuProps {
   portalIcon?: React.ReactNode;
   /** Link component to bring user to front page */
   portalLinkComponent: React.ComponentType<LinkComponent>;
+  /** Portal is external? */
+  portalExternal?: boolean;
   /** Menu items. Items can have children */
   menuSection?: MenuSection;
   /** Label for button to open submenu of menu item */
@@ -71,6 +73,7 @@ export const NavigationMenu = ({
   portalLinkLabel,
   portalIcon,
   portalLinkComponent: PortalLinkComponent,
+  portalExternal = true,
   menuSection,
   openSubMenuLabel,
   externalLinkSections,
@@ -122,7 +125,12 @@ export const NavigationMenu = ({
             </div>
             {portalLinkLabel && PortalLinkComponent ? (
               <>
-                <PortalLink label={portalLinkLabel} icon={portalIcon} component={PortalLinkComponent} />
+                <PortalLink
+                  label={portalLinkLabel}
+                  icon={portalIcon}
+                  component={PortalLinkComponent}
+                  externalLinkIconAriaLabel={portalExternal ? externalLinkIconAriaLabel : undefined}
+                />
                 {menuSection && <MenuSeparator />}
               </>
             ) : null}

--- a/lib/components/NavigationMenu/__snapshots__/NavigationMenu.test.tsx.snap
+++ b/lib/components/NavigationMenu/__snapshots__/NavigationMenu.test.tsx.snap
@@ -42,14 +42,38 @@ exports[`NavigationMenu > renders navigation menu with default state 1`] = `
         class="ds:border-l-8 ds:border-secondary-gray"
       >
         <a
-          class="ds:flex ds:flex-1 ds:gap-3 ds:p-3 ds:ml-3 ds:mr-9 ds:cursor-pointer ds:group ds:rounded ds:active:text-white ds:text-primary-gray ds:hover:bg-bg-gray ds:active:bg-secondary-1-dark-2 ds:focus-visible:outline-secondary-1-dark"
+          class="ds:ml-3 ds:flex ds:flex-1 ds:gap-3 ds:py-3 ds:cursor-pointer ds:group ds:rounded ds:active:text-white ds:text-primary-gray ds:hover:bg-bg-gray ds:active:bg-secondary-1-dark-2 ds:focus-visible:outline-secondary-1-dark"
           href="/#"
         >
-          <span
-            class="ds:text-button-md ds:group-hover:underline"
+          <div
+            class="ds:flex ds:flex-row ds:w-full ds:gap-3 ds:pr-3 ds:justify-between ds:pl-3"
           >
-            Etusivu
-          </span>
+            <span
+              class="ds:text-button-md ds:group-hover:underline"
+            >
+              Etusivu
+            </span>
+            <span
+              class="ds:sr-only"
+            >
+              Linkki johtaa palvelun ulkopuolelle
+            </span>
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="24"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.77778 20.2964C5.28889 20.2964 4.87022 20.1225 4.52178 19.7746C4.17393 19.4262 4 19.0075 4 18.5186V6.07416C4 5.58528 4.17393 5.16661 4.52178 4.81816C4.87022 4.47031 5.28889 4.29639 5.77778 4.29639H12V6.07416H5.77778V18.5186H18.2222V12.2964H20V18.5186C20 19.0075 19.8261 19.4262 19.4782 19.7746C19.1298 20.1225 18.7111 20.2964 18.2222 20.2964H5.77778ZM9.95556 15.5853L8.71111 14.3408L16.9778 6.07416H13.7778V4.29639H20V10.5186H18.2222V7.31861L9.95556 15.5853Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
         </a>
       </div>
       <hr

--- a/lib/components/NavigationMenu/components/PortalLink.tsx
+++ b/lib/components/NavigationMenu/components/PortalLink.tsx
@@ -1,3 +1,4 @@
+import { JodOpenInNew } from '../../../icons';
 import { tidyClasses, useServiceVariant } from '../../../main';
 import {
   getAccentBgClassForService,
@@ -10,11 +11,13 @@ export const PortalLink = ({
   label,
   icon,
   selected = false,
+  externalLinkIconAriaLabel,
   component: Component,
 }: {
   label: string;
   icon?: React.ReactNode;
   selected?: boolean;
+  externalLinkIconAriaLabel?: string;
   component: React.ComponentType<LinkComponent>;
 }) => {
   const variant = useServiceVariant();
@@ -23,12 +26,11 @@ export const PortalLink = ({
     <div className="ds:border-l-8 ds:border-secondary-gray">
       <Component
         className={tidyClasses([
+          'ds:ml-3',
           'ds:flex',
           'ds:flex-1',
           'ds:gap-3',
-          'ds:p-3',
-          'ds:ml-3',
-          'ds:mr-9',
+          'ds:py-3',
           'ds:cursor-pointer',
           'ds:group',
           'ds:rounded',
@@ -40,7 +42,10 @@ export const PortalLink = ({
         ])}
       >
         {icon}
-        <span className="ds:text-button-md ds:group-hover:underline">{label}</span>
+        <div className="ds:flex ds:flex-row ds:w-full ds:gap-3 ds:pr-3 ds:justify-between ds:pl-3">
+          <span className="ds:text-button-md ds:group-hover:underline">{label}</span>
+          {externalLinkIconAriaLabel && <JodOpenInNew size={24} ariaLabel={externalLinkIconAriaLabel} />}
+        </div>
       </Component>
     </div>
   );


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Add `portalExternal` prop for **NavigationMenu**
  - `true` by default as the landing-page is like the only one not needing it to be external link

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3121
