### PR TITLE
OPHJOD-3121: Update NavigationMenu's portal link to open in new page

### DIFF
--- a/lib/components/NavigationBar/MenuButton.stories.tsx
+++ b/lib/components/NavigationBar/MenuButton.stories.tsx
@@ -20,8 +20,8 @@ type Story = StoryObj<typeof meta>;
 
 const menuProps: NavigationMenuProps = {
   portalLinkLabel: 'Osaamispolkuportaali',
-  portalLinkComponent: ({ children, className }: LinkComponent) => (
-    <a href="/#" className={className}>
+  portalLinkComponent: ({ children, className, target, rel }: LinkComponent) => (
+    <a href="/#" className={className} target={target} rel={rel}>
       {children}
     </a>
   ),

--- a/lib/components/NavigationBar/NavigationBar.stories.tsx
+++ b/lib/components/NavigationBar/NavigationBar.stories.tsx
@@ -43,8 +43,8 @@ type Story = StoryObj<typeof meta>;
 
 const menuProps: NavigationMenuProps = {
   portalLinkLabel: 'Osaamispolkuportaali',
-  portalLinkComponent: ({ children, className }: LinkComponent) => (
-    <a href="/#" className={className}>
+  portalLinkComponent: ({ children, className, target, rel }: LinkComponent) => (
+    <a href="/#" className={className} target={target} rel={rel}>
       {children}
     </a>
   ),

--- a/lib/components/NavigationMenu/NavigationMenu.stories.tsx
+++ b/lib/components/NavigationMenu/NavigationMenu.stories.tsx
@@ -33,8 +33,8 @@ const parameters = {
 
 const baseProps: NavigationMenuProps = {
   portalLinkLabel: 'Osaamispolkuportaali',
-  portalLinkComponent: ({ children, className }: LinkComponent) => (
-    <a href="/#" className={className}>
+  portalLinkComponent: ({ children, className, target, rel }: LinkComponent) => (
+    <a href="/#" className={className} target={target} rel={rel}>
       {children}
     </a>
   ),

--- a/lib/components/NavigationMenu/components/PortalLink.tsx
+++ b/lib/components/NavigationMenu/components/PortalLink.tsx
@@ -25,6 +25,7 @@ export const PortalLink = ({
   return (
     <div className="ds:border-l-8 ds:border-secondary-gray">
       <Component
+        {...(externalLinkIconAriaLabel ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
         className={tidyClasses([
           'ds:ml-3',
           'ds:flex',

--- a/lib/components/NavigationMenu/types.d.ts
+++ b/lib/components/NavigationMenu/types.d.ts
@@ -1,4 +1,6 @@
 export interface LinkComponent {
   children: React.ReactNode;
   className: string;
+  target?: string;
+  rel?: string;
 }


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Update the NavigationMenu's PortalLink to open the link in new page when it is external.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3121
