### PR TITLE
OPHJOD-3346: Refactor Tag to use button for presentation variant

### DIFF
--- a/lib/components/Tag/Tag.test.tsx
+++ b/lib/components/Tag/Tag.test.tsx
@@ -23,13 +23,6 @@ describe('Tag', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should not be a button and no icons are present when using presentation variant', () => {
-    const { container, queryByRole } = render(<Tag label="presentation" variant="presentation" testId="tag3" />);
-    expect(document.querySelector('[data-testid="tag3"]')).toBeInTheDocument();
-    expect(queryByRole('button')).toBeNull();
-    expect(container.querySelector('svg')).toBeNull();
-  });
-
   it('should have cursor-pointer class when variant is not presentation', () => {
     const { container } = render(<Tag label="selectable" variant="selectable" onClick={vi.fn()} />);
     const tagElement = container.firstChild;

--- a/lib/components/Tag/Tag.tsx
+++ b/lib/components/Tag/Tag.tsx
@@ -57,15 +57,9 @@ export const Tag = ({
     <Tooltip clickToToggle={false} delay={{ open: 500, close: 150 }}>
       <TooltipTrigger asChild noAriaDescribedby noAriaExpanded>
         {variant === 'presentation' ? (
-          <div
-            className={containerClassNames(sourceType, variant)}
-            data-testid={testId}
-            aria-describedby={undefined}
-            // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-            tabIndex={tooltip ? 0 : undefined}
-          >
+          <button type="button" className={containerClassNames(sourceType, variant)} data-testid={testId}>
             <span className="ds:truncate ds:text-primary-gray ds:leading-5">{label}</span>
-          </div>
+          </button>
         ) : (
           <button
             type="button"


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Refactor Tag to use button for presentation variant
- https://github.com/Opetushallitus/jod-yksilo-ui/pull/1115
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3346
