### PR TITLE
OPHJOD-2120: Update CardCarousel

### DIFF
--- a/lib/components/CardCarousel/CardCarousel.test.tsx
+++ b/lib/components/CardCarousel/CardCarousel.test.tsx
@@ -81,6 +81,146 @@ describe('CardCarousel', () => {
     expect(container.querySelector('[data-testid="cc-list"]')).toBeInTheDocument();
     expect(container.querySelector('[data-testid="cc-controls"]')).toBeInTheDocument();
   });
+
+  describe('keyboard navigation', () => {
+    const renderWithLinks = () =>
+      renderComponent({
+        items: [
+          {
+            id: '1',
+            component: (
+              <div>
+                <a href="/card-1">Card 1</a>
+                <a href="/tag-1a">Tag 1A</a>
+              </div>
+            ),
+          },
+          {
+            id: '2',
+            component: (
+              <div>
+                <a href="/card-2">Card 2</a>
+                <a href="/tag-2a">Tag 2A</a>
+              </div>
+            ),
+          },
+          {
+            id: '3',
+            component: (
+              <div>
+                <a href="/card-3">Card 3</a>
+              </div>
+            ),
+          },
+        ],
+      });
+
+    it('first card has tabIndex 0 and others have tabIndex -1', () => {
+      const { container } = renderWithLinks();
+      const items = container.querySelectorAll('li[aria-roledescription="slide"]');
+      expect(items[0]).toHaveAttribute('tabindex', '0');
+      expect(items[1]).toHaveAttribute('tabindex', '-1');
+      expect(items[2]).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('ArrowRight moves focus to the next card', () => {
+      const { container } = renderWithLinks();
+      const items = container.querySelectorAll('li[aria-roledescription="slide"]');
+      const firstCard = items[0] as HTMLElement;
+      firstCard.focus();
+
+      fireEvent.keyDown(firstCard, { key: 'ArrowRight' });
+      expect(items[1]).toHaveAttribute('tabindex', '0');
+      expect(items[0]).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('ArrowLeft moves focus to the previous card', () => {
+      const { container } = renderWithLinks();
+      const items = container.querySelectorAll('li[aria-roledescription="slide"]');
+      const firstCard = items[0] as HTMLElement;
+      firstCard.focus();
+
+      // Move right first, then left
+      fireEvent.keyDown(firstCard, { key: 'ArrowRight' });
+      fireEvent.keyDown(items[1], { key: 'ArrowLeft' });
+      expect(items[0]).toHaveAttribute('tabindex', '0');
+    });
+
+    it('ArrowLeft does nothing on the first card', () => {
+      const { container } = renderWithLinks();
+      const items = container.querySelectorAll('li[aria-roledescription="slide"]');
+      const firstCard = items[0] as HTMLElement;
+      firstCard.focus();
+
+      fireEvent.keyDown(firstCard, { key: 'ArrowLeft' });
+      expect(items[0]).toHaveAttribute('tabindex', '0');
+    });
+
+    it('ArrowRight does nothing on the last card', () => {
+      const { container } = renderWithLinks();
+      const items = container.querySelectorAll('li[aria-roledescription="slide"]');
+      const firstCard = items[0] as HTMLElement;
+      firstCard.focus();
+
+      fireEvent.keyDown(firstCard, { key: 'ArrowRight' });
+      fireEvent.keyDown(items[1], { key: 'ArrowRight' });
+      fireEvent.keyDown(items[2], { key: 'ArrowRight' });
+      // Still on last card
+      expect(items[2]).toHaveAttribute('tabindex', '0');
+    });
+
+    it('Home moves focus to the first card', () => {
+      const { container } = renderWithLinks();
+      const items = container.querySelectorAll('li[aria-roledescription="slide"]');
+      const firstCard = items[0] as HTMLElement;
+      firstCard.focus();
+
+      fireEvent.keyDown(firstCard, { key: 'ArrowRight' });
+      fireEvent.keyDown(items[1], { key: 'ArrowRight' });
+      fireEvent.keyDown(items[2], { key: 'Home' });
+      expect(items[0]).toHaveAttribute('tabindex', '0');
+    });
+
+    it('End moves focus to the last card', () => {
+      const { container } = renderWithLinks();
+      const items = container.querySelectorAll('li[aria-roledescription="slide"]');
+      const firstCard = items[0] as HTMLElement;
+      firstCard.focus();
+
+      fireEvent.keyDown(firstCard, { key: 'End' });
+      expect(items[2]).toHaveAttribute('tabindex', '0');
+    });
+
+    it('non-active cards have their focusable children set to tabIndex -1', () => {
+      const { container } = renderWithLinks();
+      const items = container.querySelectorAll('li[aria-roledescription="slide"]');
+
+      // Active card (first) children should be focusable
+      const activeLinks = items[0].querySelectorAll('a');
+      activeLinks.forEach((link) => {
+        expect(link.tabIndex).toBe(0);
+      });
+
+      // Non-active card children should not be focusable
+      const inactiveLinks = items[1].querySelectorAll('a');
+      inactiveLinks.forEach((link) => {
+        expect(link.tabIndex).toBe(-1);
+      });
+    });
+
+    it('Escape from inside card content returns focus to the card', () => {
+      const { container } = renderWithLinks();
+      const items = container.querySelectorAll('li[aria-roledescription="slide"]');
+      const firstCard = items[0] as HTMLElement;
+      const innerLink = items[0].querySelector('a') as HTMLElement;
+
+      firstCard.focus();
+      innerLink.focus();
+
+      fireEvent.keyDown(innerLink, { key: 'Escape' });
+      expect(document.activeElement).toBe(firstCard);
+    });
+  });
 });
 
 it('has no a11y violations', async () => {

--- a/lib/components/CardCarousel/CardCarousel.tsx
+++ b/lib/components/CardCarousel/CardCarousel.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React from 'react';
 
 import { JodPagerNext, JodPagerPrev } from '../../icons';
@@ -33,12 +34,14 @@ export const CardCarousel = ({
   className = '',
   testId,
 }: CardCarouselProps) => {
-  const containerRef = React.createRef<HTMLUListElement>();
+  const containerRef = React.useRef<HTMLUListElement>(null);
+  const cardRefs = React.useRef<(HTMLLIElement | null)[]>([]);
   const [itemsPerPage, setItemsPerPage] = React.useState(1);
   const [pageNr, setPageNr] = React.useState(0);
   const [pageCount, setPageCount] = React.useState(0);
-  const [isFirstPage, setIsFirstPage] = React.useState(false);
+  const [isFirstPage, setIsFirstPage] = React.useState(true);
   const [isLastPage, setIsLastPage] = React.useState(false);
+  const [activeCardIndex, setActiveCardIndex] = React.useState(0);
   const getPageCount = React.useCallback(() => Math.ceil(items.length / itemsPerPage), [itemsPerPage, items.length]);
 
   React.useEffect(() => {
@@ -46,7 +49,81 @@ export const CardCarousel = ({
     if (current) {
       current.scrollTo({ left: pageNr * itemsPerPage * (itemWidth + gap), behavior: 'smooth' });
     }
-  }, [itemsPerPage, containerRef, itemWidth, pageNr, gap]);
+  }, [itemsPerPage, itemWidth, pageNr, gap]);
+
+  // Manage tabIndex of focusable elements inside cards so only the active card's content is tabbable
+  React.useEffect(() => {
+    const selector =
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]';
+    cardRefs.current.forEach((card, index) => {
+      if (!card) {
+        return;
+      }
+      const focusableElements = card.querySelectorAll<HTMLElement>(selector);
+      const isActive = index === activeCardIndex;
+      focusableElements.forEach((el) => {
+        el.tabIndex = isActive ? 0 : -1;
+      });
+    });
+  }, [activeCardIndex, items.length]);
+
+  const navigateToCard = (index: number) => {
+    const newIndex = Math.max(0, Math.min(index, items.length - 1));
+    // Update tabIndex immediately on DOM for responsive focus
+    cardRefs.current[activeCardIndex]?.setAttribute('tabindex', '-1');
+    cardRefs.current[newIndex]?.setAttribute('tabindex', '0');
+    cardRefs.current[newIndex]?.focus();
+    setActiveCardIndex(newIndex);
+    const newPage = Math.floor(newIndex / itemsPerPage);
+    setPageNr(newPage);
+  };
+
+  const handleCardListKeyDown = (e: React.KeyboardEvent) => {
+    const activeCard = cardRefs.current[activeCardIndex];
+    const isOnCard = e.target == activeCard;
+    const isInsideCard = activeCard?.contains(e.target as Node);
+
+    // Arrow keys navigate between cards regardless of where focus is within the card
+    if (isOnCard || isInsideCard) {
+      switch (e.key) {
+        case 'ArrowRight':
+          e.preventDefault();
+          if (activeCardIndex < items.length - 1) {
+            navigateToCard(activeCardIndex + 1);
+          }
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          if (activeCardIndex > 0) {
+            navigateToCard(activeCardIndex - 1);
+          }
+          break;
+        case 'Home':
+          e.preventDefault();
+          navigateToCard(0);
+          break;
+        case 'End':
+          e.preventDefault();
+          navigateToCard(items.length - 1);
+          break;
+      }
+    }
+
+    // Enter activates the card's main link only when focus is on the card itself
+    if (isOnCard && e.key === 'Enter') {
+      e.preventDefault();
+      const mainLink = activeCard?.querySelector<HTMLElement>('a[href]');
+      if (mainLink) {
+        mainLink.click();
+      }
+    }
+
+    // Escape from inside card content returns focus to the card
+    if (e.key === 'Escape' && !isOnCard && isInsideCard) {
+      e.preventDefault();
+      activeCard?.focus();
+    }
+  };
 
   const goToNextPage = () => {
     if (!isLastPage) {
@@ -99,7 +176,7 @@ export const CardCarousel = ({
         resizeObserver.unobserve(current);
       }
     };
-  }, [itemsPerPage, getPageCount, itemWidth, items.length, pageNr, containerRef, gap]);
+  }, [itemsPerPage, getPageCount, itemWidth, items.length, pageNr, gap]);
 
   return (
     <>
@@ -109,30 +186,22 @@ export const CardCarousel = ({
         className={`ds:flex ds:flex-row ds:overflow-hidden ${className}`.trim()}
         style={{ gap }}
         data-testid={testId ? `${testId}-list` : undefined}
+        onKeyDown={handleCardListKeyDown}
       >
-        {items.map((item, index) => {
-          // Change the page according to focused item during tab navigation
-          const onFocus = () => {
-            const pageWhereFocusedItemIs = Math.floor(index / itemsPerPage);
-            const focusedItemIsOutsideCurrentPage = pageWhereFocusedItemIs !== pageNr;
-
-            if (focusedItemIsOutsideCurrentPage) {
-              setPageNr(pageWhereFocusedItemIs);
-            }
-          };
-
-          return (
-            <li
-              key={item.id}
-              aria-roledescription="slide"
-              onFocus={onFocus}
-              className="ds:flex"
-              style={{ width: itemWidth }}
-            >
-              {item.component}
-            </li>
-          );
-        })}
+        {items.map((item, index) => (
+          <li
+            key={item.id}
+            ref={(el) => {
+              cardRefs.current[index] = el;
+            }}
+            aria-roledescription="slide"
+            tabIndex={index === activeCardIndex ? 0 : -1}
+            className={`ds:flex ds:rounded ds:outline-offset-2 ${index === activeCardIndex ? 'ds:ring-2 ds:ring-accent ds:ring-inset' : ''}`}
+            style={{ width: itemWidth }}
+          >
+            {item.component}
+          </li>
+        ))}
       </ul>
       <div
         className="ds:flex ds:flex-row ds:gap-2 ds:justify-between ds:items-center ds:p-3"

--- a/lib/components/CardCarousel/__snapshots__/CardCarousel.test.tsx.snap
+++ b/lib/components/CardCarousel/__snapshots__/CardCarousel.test.tsx.snap
@@ -8,8 +8,9 @@ exports[`CardCarousel > renders the carousel items 1`] = `
 >
   <li
     aria-roledescription="slide"
-    class="ds:flex"
+    class="ds:flex ds:rounded ds:outline-offset-2 ds:ring-2 ds:ring-accent ds:ring-inset"
     style="width: 200px;"
+    tabindex="0"
   >
     <div>
       Item 1
@@ -17,8 +18,9 @@ exports[`CardCarousel > renders the carousel items 1`] = `
   </li>
   <li
     aria-roledescription="slide"
-    class="ds:flex"
+    class="ds:flex ds:rounded ds:outline-offset-2 "
     style="width: 200px;"
+    tabindex="-1"
   >
     <div>
       Item 2
@@ -26,8 +28,9 @@ exports[`CardCarousel > renders the carousel items 1`] = `
   </li>
   <li
     aria-roledescription="slide"
-    class="ds:flex"
+    class="ds:flex ds:rounded ds:outline-offset-2 "
     style="width: 200px;"
+    tabindex="-1"
   >
     <div>
       Item 3

--- a/lib/components/MediaCard/MediaCard.tsx
+++ b/lib/components/MediaCard/MediaCard.tsx
@@ -97,7 +97,7 @@ const LinkOrDiv = ({
   return Link && to ? (
     <Link
       to={to}
-      className={`ds:z-1 ds:before:content-[''] ds:before:absolute ds:before:w-full ds:before:h-full ${className}`}
+      className={`ds:z-1 ds:before:content-[''] ds:before:absolute ds:before:w-full ds:before:h-full ds:focus-visible:outline-offset-[-6px] ${className}`}
     >
       {children}
     </Link>
@@ -111,7 +111,7 @@ const LinkOrDiv = ({
 const FavoriteButton = ({ isFavorite, favoriteLabel, onFavoriteClick }: FavoriteButtonProps) => {
   return (
     <button
-      className="ds:cursor-pointer ds:absolute ds:top-0 ds:right-0 ds:p-[12px] ds:bg-white ds:rounded-bl ds:z-1"
+      className="ds:cursor-pointer ds:absolute ds:top-0 ds:right-0 ds:p-4 ds:bg-white ds:rounded-bl ds:z-2"
       aria-label={favoriteLabel}
       onClick={onFavoriteClick}
     >
@@ -210,7 +210,7 @@ const MediaCardVertical = ({
               {label}
             </p>
           </div>
-          <div className="ds:flex-grow ds:content-center">
+          <div className="ds:grow ds:content-center">
             <p
               className="ds:text-body-sm-mobile ds:sm:text-body-sm ds:line-clamp-3 ds:hyphens-auto"
               data-testid={testId ? `${testId}-description` : undefined}
@@ -288,7 +288,7 @@ const MediaCardHorizontal = ({
           className="ds:px-5 ds:pt-4 ds:pb-5 ds:text-primary-gray ds:flex ds:flex-col ds:justify-between ds:flex-nowrap"
           ref={textContainerRef}
         >
-          <div className="ds:gap-3 ds:flex ds:flex-col ds:flex-grow">
+          <div className="ds:gap-3 ds:flex ds:flex-col ds:grow">
             <div>
               <p
                 className="ds:pr-6 ds:text-heading-4-mobile ds:sm:text-heading-4 ds:line-clamp-4 ds:sm:line-clamp-2"
@@ -297,7 +297,7 @@ const MediaCardHorizontal = ({
                 {label}
               </p>
             </div>
-            <div className="ds:flex-grow ds:content-center">
+            <div className="ds:grow ds:content-center">
               <p
                 className="ds:text-body-sm-mobile ds:sm:text-body-sm ds:line-clamp-3 ds:sm:line-clamp-2"
                 data-testid={testId ? `${testId}-description` : undefined}

--- a/lib/components/MediaCard/__snapshots__/MediaCard.test.tsx.snap
+++ b/lib/components/MediaCard/__snapshots__/MediaCard.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`MediaCard > renders the MediaCard component with default vertical varia
         </p>
       </div>
       <div
-        class="ds:flex-grow ds:content-center"
+        class="ds:grow ds:content-center"
       >
         <p
           class="ds:text-body-sm-mobile ds:sm:text-body-sm ds:line-clamp-3 ds:hyphens-auto"


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

- Update `CardCarousel` component by improving accessibility
  - cards/slides are now using roving tabindex pattern style
  - Update outlines to be visible when having keyboard focus
    - earlier it was clipped/not shown so clearly


### Notes

Favorite button is over the outline of link when focused, that is not a deal break as the focus is still clearly visible.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2120
