### PR TITLE
OPHJOD-3391: Add more button stories

### DIFF
--- a/lib/components/Button/Button.stories.tsx
+++ b/lib/components/Button/Button.stories.tsx
@@ -1,7 +1,8 @@
+import { Controls, Description, Primary, Stories, Subtitle, Title } from '@storybook/addon-docs/blocks';
 import type { StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
-import { JodArrowLeft, JodEdit, JodUser } from '../../icons';
+import { JodArrowLeft, JodArrowRight, JodEdit, JodUser } from '../../icons';
 import type { TitledMeta } from '../../utils';
 import { Button } from './Button';
 
@@ -11,6 +12,16 @@ const meta = {
   tags: ['autodocs'],
   parameters: {
     docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+          <Controls />
+          <Stories includePrimary={false} />
+        </>
+      ),
       description: {
         component: 'Button component for user actions.',
       },
@@ -69,6 +80,11 @@ export const AllVariants: Story = {
         cmp: <Button {...args} variant="gray" size="sm" />,
         cmpDisabled: <Button {...args} variant="gray" size="sm" disabled />,
       },
+      {
+        label: 'Gray with left icon',
+        cmp: <Button {...args} variant="gray" size="sm" icon={<JodUser />} iconSide="left" />,
+        cmpDisabled: <Button {...args} variant="gray" size="sm" icon={<JodUser />} iconSide="left" disabled />,
+      },
     ];
 
     const lgButtons = [
@@ -101,6 +117,11 @@ export const AllVariants: Story = {
         label: 'Gray',
         cmp: <Button {...args} variant="gray" size="lg" />,
         cmpDisabled: <Button {...args} variant="gray" size="lg" disabled />,
+      },
+      {
+        label: 'Gray with left icon',
+        cmp: <Button {...args} variant="gray" size="lg" icon={<JodUser />} iconSide="left" />,
+        cmpDisabled: <Button {...args} variant="gray" size="lg" icon={<JodUser />} iconSide="left" disabled />,
       },
     ];
 
@@ -241,6 +262,25 @@ export const Small: Story = {
   },
 };
 
+export const SmallWithRightIcon: Story = {
+  parameters: {
+    design,
+    docs: {
+      description: {
+        story: 'This is a small button component with an right icon.',
+      },
+    },
+  },
+  args: {
+    label: 'Seuraava',
+    onClick: fn(),
+    size: 'sm',
+    variant: 'white',
+    iconSide: 'right',
+    icon: <JodArrowRight size={20} />,
+  },
+};
+
 export const LargeWithLeftIcon: Story = {
   parameters: {
     design,
@@ -256,6 +296,24 @@ export const LargeWithLeftIcon: Story = {
     variant: 'white',
     iconSide: 'left',
     icon: <JodArrowLeft size={24} />,
+  },
+};
+
+export const LargeWithRightIcon: Story = {
+  parameters: {
+    design,
+    docs: {
+      description: {
+        story: 'This is a large button component with an right icon.',
+      },
+    },
+  },
+  args: {
+    label: 'Seuraava',
+    onClick: fn(),
+    variant: 'white',
+    iconSide: 'right',
+    icon: <JodArrowRight size={24} />,
   },
 };
 


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
Add more button stories. Don't show first story twice in button story.
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3391
