### PR TITLE
OPHJOD-3372: Fix Button color conflicts

### DIFF
--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -83,13 +83,13 @@ const buttonVariants = cvaBase({
       lg: 'ds:text-button-md',
     },
     variant: {
-      accent: 'ds:text-white',
-      white: 'ds:bg-white ds:text-primary-gray',
-      gray: 'ds:bg-bg-gray ds:text-primary-gray',
+      accent: '',
+      white: '',
+      gray: '',
       plain: '',
-      'red-delete': 'ds:bg-alert ds:active:bg-alert-text-2 ds:focus-visible:outline-alert ds:text-white',
+      'red-delete': 'ds:active:bg-alert-text-2 ds:focus-visible:outline-alert',
       'white-delete':
-        'ds:bg-white ds:text-alert-text ds:active:text-alert-text-2 ds:focus-visible:text-alert-text-2 ds:focus-visible ds:outline-alert-text-2',
+        'ds:active:text-alert-text-2 ds:focus-visible:text-alert-text-2 ds:focus-visible ds:outline-alert-text-2',
     },
     serviceVariant: {
       yksilo: '',
@@ -137,7 +137,14 @@ const buttonVariants = cvaBase({
     // Service-specific colors (accent, white, gray, plain)
     ...createServiceVariants(),
 
-    // Disabled styles
+    // Colors (enabled)
+    { variant: 'accent', disabled: false, class: 'ds:text-white' },
+    { variant: 'white', disabled: false, class: 'ds:bg-white ds:text-primary-gray' },
+    { variant: 'gray', disabled: false, class: 'ds:bg-bg-gray ds:text-primary-gray' },
+    { variant: 'red-delete', disabled: false, class: 'ds:bg-alert ds:text-white' },
+    { variant: 'white-delete', disabled: false, class: 'ds:bg-white ds:text-alert-text' },
+
+    // Colors (disabled)
     { variant: 'plain', disabled: true, class: 'ds:text-inactive-gray' },
     { variant: 'white', disabled: true, class: 'ds:text-inactive-gray' },
     { variant: 'white-delete', disabled: true, class: 'ds:text-inactive-gray' },

--- a/lib/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/lib/components/Button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button > calls the onClick function when clicked 1`] = `
 <button
   aria-label="Click me"
-  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:bg-white ds:text-primary-gray ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark"
+  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark ds:bg-white ds:text-primary-gray"
   type="button"
 >
   <span
@@ -17,7 +17,7 @@ exports[`Button > calls the onClick function when clicked 1`] = `
 exports[`Button > renders the button as disabled 1`] = `
 <button
   aria-label="Click me"
-  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:bg-white ds:text-primary-gray ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:text-inactive-gray"
+  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:text-inactive-gray"
   disabled=""
   type="button"
 >
@@ -32,7 +32,7 @@ exports[`Button > renders the button as disabled 1`] = `
 exports[`Button > renders the button with the correct label 1`] = `
 <button
   aria-label="Click me"
-  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:bg-white ds:text-primary-gray ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark"
+  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark ds:bg-white ds:text-primary-gray"
   type="button"
 >
   <span
@@ -46,7 +46,7 @@ exports[`Button > renders the button with the correct label 1`] = `
 exports[`Button > renders the button with the correct size 1`] = `
 <button
   aria-label="Click me"
-  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-sm ds:bg-white ds:text-primary-gray ds:rounded-[30px] ds:px-5 ds:min-h-7 ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark"
+  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-sm ds:rounded-[30px] ds:px-5 ds:min-h-7 ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark ds:bg-white ds:text-primary-gray"
   type="button"
 >
   <span
@@ -60,7 +60,7 @@ exports[`Button > renders the button with the correct size 1`] = `
 exports[`Button > renders the button with the correct variant 1`] = `
 <button
   aria-label="Click me"
-  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:text-white ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:bg-secondary-1-dark ds:active:bg-secondary-1-dark-2 ds:focus-visible:outline-secondary-1-dark"
+  class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:bg-secondary-1-dark ds:active:bg-secondary-1-dark-2 ds:focus-visible:outline-secondary-1-dark ds:text-white"
   type="button"
 >
   <span

--- a/lib/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/lib/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Footer > renders 1`] = `
           <button
             aria-haspopup="dialog"
             aria-label="Feedback"
-            class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:bg-white ds:text-primary-gray ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:pr-[20px] ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark ds:mt-4 ds:w-fit ds:group-focus:underline ds:group-focus:text-accent"
+            class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:pr-[20px] ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark ds:bg-white ds:text-primary-gray ds:mt-4 ds:w-fit ds:group-focus:underline ds:group-focus:text-accent"
             type="button"
           >
             <span
@@ -652,7 +652,7 @@ exports[`Footer > renders copyright 1`] = `
           <button
             aria-haspopup="dialog"
             aria-label="Feedback"
-            class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:bg-white ds:text-primary-gray ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:pr-[20px] ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark ds:mt-4 ds:w-fit ds:group-focus:underline ds:group-focus:text-accent"
+            class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:flex ds:text-button-md ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:pr-[20px] ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark ds:bg-white ds:text-primary-gray ds:mt-4 ds:w-fit ds:group-focus:underline ds:group-focus:text-accent"
             type="button"
           >
             <span

--- a/lib/components/HeroCard/__snapshots__/HeroCard.test.tsx.snap
+++ b/lib/components/HeroCard/__snapshots__/HeroCard.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`HeroCard > renders HeroCard with a button 1`] = `
   </p>
   <div>
     <a
-      class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:inline-flex ds:text-button-md ds:bg-white ds:text-primary-gray ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:pr-[20px] ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark ds:mt-4 ds:w-fit ds:group-focus:underline ds:group-focus:text-accent ds:group ds:outline-hidden"
+      class="ds:cursor-pointer ds:items-center ds:gap-2 ds:select-none ds:group ds:outline-offset-2 ds:disabled:cursor-not-allowed ds:inline-flex ds:text-button-md ds:rounded-[30px] ds:px-6 ds:min-h-9 ds:pr-[20px] ds:hover:text-secondary-1-dark ds:active:text-secondary-1-dark-2 ds:focus-visible:text-secondary-1-dark ds:focus-visible:outline-secondary-1-dark ds:bg-white ds:text-primary-gray ds:mt-4 ds:w-fit ds:group-focus:underline ds:group-focus:text-accent ds:group ds:outline-hidden"
       href="/"
     >
       <span


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Fix Button color conflicts. No actual colors changed, yet.

## Screenshots

### Before
<img width="600" alt="SCR-20260520-nhqb" src="https://github.com/user-attachments/assets/cf28e7fd-b165-44e5-9168-4ca3ffcd083c" />

### After
<img width="600" alt="SCR-20260520-nhtc" src="https://github.com/user-attachments/assets/2f33dc2c-1581-40cd-89ed-894d1e056bbf" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3372
