### PR TITLE
OPHJOD-3404: Add MainLayout component

### DIFF
--- a/lib/components/MainLayout/MainLayout.stories.tsx
+++ b/lib/components/MainLayout/MainLayout.stories.tsx
@@ -1,0 +1,103 @@
+import type { StoryObj } from '@storybook/react-vite';
+
+import { ServiceVariantProvider } from '../../hooks/useServiceVariant';
+import { useMediaQueries } from '../../main';
+import type { TitledMeta } from '../../utils';
+import { LinkComponent, MenuSection } from '../NavigationMenu';
+import { PageNavigation } from '../PageNavigation/PageNavigation';
+import { MainLayout } from './MainLayout';
+
+const meta = {
+  title: 'Content/MainLayout',
+  component: MainLayout,
+  tags: ['autodocs'],
+} satisfies TitledMeta<typeof MainLayout>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Not as a component in Figma
+
+const sections = [
+  {
+    navTitle: 'Description',
+    showDivider: false,
+    showAiInfoInTitle: true,
+    content: <p className="ds:font-arial ds:text-body-md ds:whitespace-pre-line"></p>,
+  },
+  {
+    navTitle: 'Most common tasks',
+    showDivider: false,
+    showAiInfoInTitle: true,
+    content: (
+      <ul className="ds:ml-7 ds:list-disc">
+        <li key="aaa" className="ds:text-capitalize ds:font-arial ds:text-body-md ds:text-primary-gray">
+          A
+        </li>
+        <li key="bbb" className="ds:text-capitalize ds:font-arial ds:text-body-md ds:text-primary-gray">
+          B
+        </li>
+        <li key="ccc" className="ds:text-capitalize ds:font-arial ds:text-body-md ds:text-primary-gray">
+          C
+        </li>
+      </ul>
+    ),
+  },
+];
+
+// oxlint-disable-next-line jsx_a11y/anchor-has-content jsx_a11y/anchor-is-valid
+const DummyLink = (props: LinkComponent) => <a href="#" {...props} />;
+
+const menuSection: MenuSection = {
+  title: 'On this page',
+  linkItems: sections.map((section) => ({
+    label: section.navTitle,
+    linkComponent: DummyLink,
+  })),
+};
+
+const navChildren = (
+  <ServiceVariantProvider value="yksilo">
+    <div className="ds:flex ds:flex-col ds:gap-6">
+      <PageNavigation menuSection={menuSection} activeIndicator="dot" />
+    </div>
+  </ServiceVariantProvider>
+);
+
+const DefaultRender = (args: Story['args']) => {
+  const { lg } = useMediaQueries();
+
+  return (
+    <div className="ds:bg-bg-gray">
+      <MainLayout {...args}>
+        <div className="ds:px-5">
+          {!lg && menuSection.linkItems.length > 0 && (
+            <ServiceVariantProvider value="yksilo">
+              <div className="ds:mb-8 ds:print:hidden">
+                <PageNavigation menuSection={menuSection} collapsed />
+              </div>
+            </ServiceVariantProvider>
+          )}
+          <div className="ds:mt-6">Test content</div>
+        </div>
+      </MainLayout>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: DefaultRender,
+  parameters: {
+    docs: {
+      description: {
+        story: 'MainLayout with minimal implementation',
+      },
+    },
+  },
+  args: {
+    children: <div>Test content</div>,
+    breadcrumbComponent: null,
+    navChildren: navChildren,
+  },
+};

--- a/lib/components/MainLayout/MainLayout.test.tsx
+++ b/lib/components/MainLayout/MainLayout.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import { MainLayout } from './MainLayout';
+
+describe('MainLayout', () => {
+  it('renders the component with correct title', () => {
+    const { container } = render(
+      <MainLayout breadcrumbComponent={null}>
+        <div>Test content</div>
+      </MainLayout>,
+    );
+    const component = screen.getByRole('main');
+    expect(component).toBeInTheDocument();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('has no a11y violations', async () => {
+    const { container } = render(
+      <MainLayout breadcrumbComponent={null}>
+        <div>Test content</div>
+      </MainLayout>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/lib/components/MainLayout/MainLayout.tsx
+++ b/lib/components/MainLayout/MainLayout.tsx
@@ -1,0 +1,35 @@
+import { useMediaQueries } from '../../hooks/useMediaQueries';
+
+interface MainLayoutProps {
+  children: React.ReactNode;
+  navChildren?: React.ReactNode;
+  hideBreadcrumb?: boolean;
+  breadcrumbComponent: React.ReactNode;
+}
+
+export const MainLayout = ({ children, navChildren, hideBreadcrumb = false, breadcrumbComponent }: MainLayoutProps) => {
+  const { lg } = useMediaQueries();
+
+  return (
+    <div
+      className="ds:mx-auto ds:grid ds:w-full ds:max-w-[1140px] ds:grow ds:grid-cols-3 ds:gap-6 ds:pt-11 ds:pb-6 ds:print:flex ds:print:p-0"
+      data-testid="main-layout"
+    >
+      {!hideBreadcrumb && <div className="ds:col-span-3 ds:px-5 ds:sm:px-6">{breadcrumbComponent}</div>}
+
+      {lg && navChildren && (
+        <aside className="ds:order-last ds:col-span-1 ds:mr-5 ds:sm:mr-6 ds:print:hidden" data-testid="sidebar">
+          <nav data-testid="sidebar-nav">{navChildren}</nav>
+        </aside>
+      )}
+      <main
+        role="main"
+        className="ds:col-span-3 ds:lg:col-span-2 ds:print:col-span-3"
+        id="jod-main"
+        data-testid="main-content"
+      >
+        {children}
+      </main>
+    </div>
+  );
+};

--- a/lib/components/MainLayout/__snapshots__/MainLayout.test.tsx.snap
+++ b/lib/components/MainLayout/__snapshots__/MainLayout.test.tsx.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MainLayout > renders the component with correct title 1`] = `
+<div
+  class="ds:mx-auto ds:grid ds:w-full ds:max-w-[1140px] ds:grow ds:grid-cols-3 ds:gap-6 ds:pt-11 ds:pb-6 ds:print:flex ds:print:p-0"
+  data-testid="main-layout"
+>
+  <div
+    class="ds:col-span-3 ds:px-5 ds:sm:px-6"
+  />
+  <main
+    class="ds:col-span-3 ds:lg:col-span-2 ds:print:col-span-3"
+    data-testid="main-content"
+    id="jod-main"
+    role="main"
+  >
+    <div>
+      Test content
+    </div>
+  </main>
+</div>
+`;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -75,6 +75,7 @@ export {
   type PermanentNoteStackElement,
   type TemporaryNoteStackElement,
 } from './components/NavigationBar';
+export { MainLayout } from './components/MainLayout/MainLayout';
 export {
   ExternalLinkSections,
   LanguageSelection,


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Add `MainLayout` component

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3404
