### PR TITLE
OPHJOD-3442: Fix IconHeading icon squishing

### DIFF
--- a/lib/components/IconHeading/IconHeading.stories.tsx
+++ b/lib/components/IconHeading/IconHeading.stories.tsx
@@ -1,6 +1,6 @@
 import type { StoryObj } from '@storybook/react-vite';
 
-import { JodCompass } from '../../icons';
+import { JodCompass, JodInfo } from '../../icons';
 import type { TitledMeta } from '../../utils';
 import { IconHeading } from './IconHeading';
 
@@ -27,5 +27,19 @@ export const Default: Story = {
   args: {
     title: 'Etsi mahdollisuuksia',
     icon: <JodCompass />,
+  },
+};
+
+export const LongText: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Long text',
+      },
+    },
+  },
+  args: {
+    title: 'Tietosuojaseloste ja evästeet',
+    icon: <JodInfo />,
   },
 };

--- a/lib/components/IconHeading/IconHeading.tsx
+++ b/lib/components/IconHeading/IconHeading.tsx
@@ -20,7 +20,7 @@ export const IconHeading = ({
       {icon && (
         <span
           aria-hidden="true"
-          className={`ds:flex ds:size-9 ds:items-center ds:justify-center ds:rounded-full ds:text-white aspect-square ${bgClassName} ds:print:hidden`}
+          className={`ds:flex ds:size-9 ds:items-center ds:justify-center ds:aspect-square ds:rounded-full ds:text-white ${bgClassName} ds:print:hidden`}
         >
           {icon}
         </span>

--- a/lib/components/IconHeading/__snapshots__/IconHeading.test.tsx.snap
+++ b/lib/components/IconHeading/__snapshots__/IconHeading.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`IconHeading > renders the component with correct title 1`] = `
 >
   <span
     aria-hidden="true"
-    class="ds:flex ds:size-9 ds:items-center ds:justify-center ds:rounded-full ds:text-white aspect-square ds:bg-secondary-1-dark ds:print:hidden"
+    class="ds:flex ds:size-9 ds:items-center ds:justify-center ds:aspect-square ds:rounded-full ds:text-white ds:bg-secondary-1-dark ds:print:hidden"
   >
     <svg
       fill="currentColor"


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->
Fix icon getting squished with `IconHeading` with long text.


## Screenshots

### Before
<img width="300"  alt="SCR-20260604-itzf" src="https://github.com/user-attachments/assets/ab674b2b-0d32-4dcb-b48a-a29199066309" />



### After
<img width="300"  alt="SCR-20260604-iubg" src="https://github.com/user-attachments/assets/38d11283-cf6b-44e9-b9c2-1d7a76cc70f5" />



## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3442
