### PR TITLE
OPHJOD-3443: Add ActionButton component

### DIFF
--- a/lib/components/ActionButton/ActionButton.stories.tsx
+++ b/lib/components/ActionButton/ActionButton.stories.tsx
@@ -1,0 +1,31 @@
+import type { StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { JodPrint } from '../../icons';
+import type { TitledMeta } from '../../utils';
+import { ActionButton } from './ActionButton';
+
+const meta = {
+  title: 'Buttons/ActionButton',
+  component: ActionButton,
+  tags: ['autodocs'],
+} satisfies TitledMeta<typeof ActionButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/dgMOsST06t4TvDcBA9lcki/Osaamispolku-_-Design-system?node-id=660-3367',
+    },
+  },
+  args: {
+    label: 'Tulosta',
+    icon: <JodPrint className="ds:text-accent" />,
+    onClick: fn(),
+    className: 'ds:bg-bg-gray-2',
+  },
+};

--- a/lib/components/ActionButton/ActionButton.test.tsx
+++ b/lib/components/ActionButton/ActionButton.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+import { JodPrint, JodShare } from '../../icons';
+import { ActionButton } from './ActionButton';
+
+describe('ActionButton', () => {
+  const onClick = vi.fn<() => void>();
+
+  it('matches the snapshot', () => {
+    const { container } = render(
+      <ActionButton label="Print" icon={<JodPrint className="ds:text-accent" />} onClick={onClick} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders the label correctly', () => {
+    render(<ActionButton label="Jaa" icon={<JodShare className="ds:text-accent" />} onClick={onClick} />);
+    expect(screen.getByText('Jaa')).not.toBeNull();
+  });
+
+  it('calls the onClick funtion when pressed', () => {
+    render(<ActionButton label="Jaa" icon={<JodShare className="ds:text-accent" />} onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds the custom classname correctly', () => {
+    render(
+      <ActionButton
+        className="added-classname"
+        label="Jaa"
+        icon={<JodShare className="ds:text-accent" />}
+        onClick={onClick}
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveClass('added-classname');
+  });
+
+  it('has no a11y violations', async () => {
+    const { container } = render(
+      <ActionButton label="Print" icon={<JodPrint className="ds:text-accent" />} onClick={onClick} />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/lib/components/ActionButton/ActionButton.tsx
+++ b/lib/components/ActionButton/ActionButton.tsx
@@ -1,0 +1,29 @@
+import { cx } from '../../cva';
+
+type ActionButtonProps = {
+  label: string;
+  icon: React.ReactNode;
+  className?: string;
+  onClick: () => void;
+  testId?: string;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const ActionButton = ({ label, icon, className, onClick, testId, ...rest }: ActionButtonProps) => {
+  return (
+    <button
+      aria-label={label}
+      className={cx(
+        'ds:font-semibold ds:text-[0.75rem] ds:leading-[1.125rem] ds:text-nowrap',
+        'ds:rounded-2xl ds:flex ds:cursor-pointer ds:items-center ds:gap-x-2 ds:py-1 ds:pr-5 ds:pl-4 ds:outline-accent ds:hover:underline',
+        className,
+      )}
+      onClick={onClick}
+      type="button"
+      data-testid={testId}
+      {...rest}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+};

--- a/lib/components/ActionButton/__snapshots__/ActionButton.test.tsx.snap
+++ b/lib/components/ActionButton/__snapshots__/ActionButton.test.tsx.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ActionButton > matches the snapshot 1`] = `
+<div>
+  <button
+    aria-label="Print"
+    class="ds:font-semibold ds:text-[0.75rem] ds:leading-[1.125rem] ds:text-nowrap ds:rounded-2xl ds:flex ds:cursor-pointer ds:items-center ds:gap-x-2 ds:py-1 ds:pr-5 ds:pl-4 ds:outline-accent ds:hover:underline"
+    type="button"
+  >
+    <svg
+      class="ds:text-accent"
+      fill="currentColor"
+      height="24"
+      stroke="currentColor"
+      stroke-width="0"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M16 8.29639V5.29639H8V8.29639H6V3.29639H18V8.29639H16ZM18 12.7964C18.2833 12.7964 18.5208 12.7006 18.7125 12.5089C18.9042 12.3172 19 12.0797 19 11.7964C19 11.5131 18.9042 11.2756 18.7125 11.0839C18.5208 10.8922 18.2833 10.7964 18 10.7964C17.7167 10.7964 17.4792 10.8922 17.2875 11.0839C17.0958 11.2756 17 11.5131 17 11.7964C17 12.0797 17.0958 12.3172 17.2875 12.5089C17.4792 12.7006 17.7167 12.7964 18 12.7964ZM16 19.2964V15.2964H8V19.2964H16ZM18 21.2964H6V17.2964H2V11.2964C2 10.4464 2.29167 9.73389 2.875 9.15889C3.45833 8.58389 4.16667 8.29639 5 8.29639H19C19.85 8.29639 20.5625 8.58389 21.1375 9.15889C21.7125 9.73389 22 10.4464 22 11.2964V17.2964H18V21.2964ZM20 15.2964V11.2964C20 11.0131 19.9042 10.7756 19.7125 10.5839C19.5208 10.3922 19.2833 10.2964 19 10.2964H5C4.71667 10.2964 4.47917 10.3922 4.2875 10.5839C4.09583 10.7756 4 11.0131 4 11.2964V15.2964H6V13.2964H18V15.2964H20Z"
+        fill="currentColor"
+      />
+    </svg>
+    Print
+  </button>
+</div>
+`;


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Add `ActionButton` component

### Screenshot

<img width="250"  alt="image" src="https://github.com/user-attachments/assets/5e1501c1-a83d-43b8-8dd6-c0722395d3d4" />

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3443