### PR TITLE
OPHJOD-3468: Update Tag tooltip for screenreaders

### DIFF
--- a/lib/components/Tag/Tag.tsx
+++ b/lib/components/Tag/Tag.tsx
@@ -60,6 +60,7 @@ export const Tag = ({
         {variant === 'presentation' ? (
           <button type="button" className={containerClassNames(sourceType, variant)} data-testid={testId}>
             <span className="ds:truncate ds:text-primary-gray ds:leading-5">{label}</span>
+            {screenReaderTooltip && <span className="ds:sr-only">{screenReaderTooltip}</span>}
           </button>
         ) : (
           <button
@@ -72,21 +73,19 @@ export const Tag = ({
             <span className="ds:pl-3 ds:text-button-md ds:text-primary-gray ds:leading-5" aria-hidden>
               {variant === 'selectable' ? <JodAdd size={16} /> : <JodClose size={16} />}
             </span>
+            {screenReaderTooltip && <span className="ds:sr-only">{screenReaderTooltip}</span>}
           </button>
         )}
       </TooltipTrigger>
       {tooltip && (
-        <>
-          <TooltipContent>
-            <div className="ds:font-arial ds:text-white ds:leading-5 ds:text-card-label">
-              <p className="ds:mb-2 ds:capitalize" aria-hidden>
-                {label}
-              </p>
-              <p className="ds:font-normal">{tooltip}</p>
-            </div>
-          </TooltipContent>
-          <div className="ds:sr-only">{screenReaderTooltip}</div>
-        </>
+        <TooltipContent>
+          <div className="ds:font-arial ds:text-white ds:leading-5 ds:text-card-label">
+            <p className="ds:mb-2 ds:capitalize" aria-hidden>
+              {label}
+            </p>
+            <p className="ds:font-normal">{tooltip}</p>
+          </div>
+        </TooltipContent>
       )}
     </Tooltip>
   );


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Update the Tag's tooltip to work on screenreaders.

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3468
