### PR TITLE
OPHJOD-3461: Refactor MatomoTracker to use pathname for setCustomUrl

### DIFF
--- a/lib/components/MatomoTracker/MatomoTracker.test.tsx
+++ b/lib/components/MatomoTracker/MatomoTracker.test.tsx
@@ -44,4 +44,32 @@ describe('MatomoTracker', () => {
     render(<MatomoTracker trackerUrl={trackerUrl} siteId={siteId} pathname="/foo" />);
     expect(window._paq).toBeUndefined();
   });
+
+  it('tracks page view with URL without query parameters', () => {
+    (window as any).location = {
+      ...window.location,
+      href: 'https://example.com/test?foo=bar&baz=qux',
+      origin: 'https://example.com',
+      pathname: '/test',
+    };
+    const paq: unknown[] = [];
+    (window as any)._paq = paq;
+    render(<MatomoTracker trackerUrl={trackerUrl} siteId={siteId} pathname="/test" />);
+    expect(paq).toContainEqual(['setCustomUrl', 'https://example.com/test']);
+    expect(paq).not.toContainEqual(['setCustomUrl', 'https://example.com/test?foo=bar&baz=qux']);
+  });
+
+  it('does not include query parameters in setCustomUrl even when present', () => {
+    (window as any).location = {
+      ...window.location,
+      href: 'https://example.com/page?token=secret',
+      origin: 'https://example.com',
+      pathname: '/page',
+    };
+    const paq: unknown[] = [];
+    (window as any)._paq = paq;
+    render(<MatomoTracker trackerUrl={trackerUrl} siteId={siteId} pathname="/page" />);
+    const setCustomUrlCall = (paq as unknown[][]).find(([cmd]) => cmd === 'setCustomUrl');
+    expect(setCustomUrlCall?.[1]).toBe('https://example.com/page');
+  });
 });

--- a/lib/components/MatomoTracker/MatomoTracker.tsx
+++ b/lib/components/MatomoTracker/MatomoTracker.tsx
@@ -23,7 +23,7 @@ export const MatomoTracker = ({ trackerUrl, siteId, pathname }: TrackerProps) =>
 
   React.useEffect(() => {
     if (window._paq && pathname !== oldPathname) {
-      window._paq.push(['setCustomUrl', window.location.href]);
+      window._paq.push(['setCustomUrl', `${window.location.origin}${window.location.pathname}`]);
       window._paq.push(['setDocumentTitle', document.title]);
       window._paq.push(['trackPageView']);
       oldPathname = pathname;


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Refactor MatomoTracker to use pathname for setCustomUrl
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3461
